### PR TITLE
Refactor

### DIFF
--- a/nanopub/__init__.py
+++ b/nanopub/__init__.py
@@ -1,2 +1,2 @@
-from .nanopub import Nanopub
+from .nanopub import NanopubClient
 from ._version import __version__

--- a/nanopub/namespaces.py
+++ b/nanopub/namespaces.py
@@ -1,0 +1,11 @@
+import rdflib
+
+NP = rdflib.Namespace("http://www.nanopub.org/nschema#")
+NPX = rdflib.Namespace("http://purl.org/nanopub/x/")
+PPLAN = rdflib.Namespace("http://purl.org/net/p-plan#")
+PROV = rdflib.Namespace("http://www.w3.org/ns/prov#")
+DUL = rdflib.Namespace("http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#")
+BPMN = rdflib.Namespace("http://dkm.fbk.eu/index.php/BPMN2_Ontology#")
+PWO = rdflib.Namespace("http://purl.org/spar/pwo/")
+HYCL = rdflib.Namespace("http://purl.org/petapico/o/hycl#")
+AUTHOR = rdflib.Namespace("http://purl.org/person#")

--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -271,7 +271,8 @@ class NanopubClient:
         return np_rdf
 
     @staticmethod
-    def publish(assertionrdf, uri=None, introduces_concept=None, derived_from=None, attributed_to=None, nanopub_author=None):
+    def publish(self, assertionrdf, uri=None, introduces_concept=None, derived_from=None,
+                attributed_to=None, nanopub_author=None):
         """
         Publish the given assertion as a nanopublication with the given URI.
         Uses np commandline tool to sign and publish.
@@ -280,10 +281,12 @@ class NanopubClient:
         method in this module.
         """
 
-        if uri is None:
-            np_rdf = NanopubClient.to_rdf(assertionrdf, introduces_concept=introduces_concept, derived_from=derived_from, attributed_to=attributed_to, nanopub_author=nanopub_author)
-        else:
-            np_rdf = NanopubClient.to_rdf(assertionrdf, uri=uri, introduces_concept=introduces_concept, derived_from=derived_from, attributed_to=attributed_to, nanopub_author=nanopub_author)
+        np_rdf = self.to_rdf(assertionrdf=assertionrdf,
+                             uri=uri,
+                             introduces_concept=introduces_concept,
+                             derived_from=derived_from,
+                             attributed_to=attributed_to,
+                             nanopub_author=nanopub_author)
 
         # Create a temporary dir for files created during serializing and signing
         tempdir = tempfile.mkdtemp()

--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -13,6 +13,177 @@ from nanopub import java_wrapper, namespaces
 DEFAULT_URI = 'http://purl.org/nanopub/temp/mynanopub'
 
 
+class Nanopub:
+    """
+    Representation of the rdf that comprises a nanopublication
+    """
+    def __init__(self, rdf=None, source_uri=None):
+        self._rdf = rdf
+        self._source_uri = source_uri
+
+        # Extract the Head, pubinfo, provenance and assertion graphs from the assigned nanopub rdf
+        self._graphs = {}
+        for c in rdf.contexts():
+            graphid = urldefrag(c.identifier).fragment.lower()
+            self._graphs[graphid] = c
+
+        # Check all four expected graphs are provided
+        expected_graphs = ['head', 'pubinfo', 'provenance', 'assertion']
+        for expected in expected_graphs:
+            if expected not in self._graphs.keys():
+                raise ValueError(
+                    f'Expected to find {expected} graph in nanopub rdf, but not found. Graphs found: {list(self._graphs.keys())}.')
+
+        self._introduces_concept = None
+
+    @classmethod
+    def from_assertion(cls, assertion_rdf, uri=DEFAULT_URI, introduces_concept=None,
+                       derived_from=None,
+                       attributed_to=None, nanopub_author=None):
+        """
+        Construct Nanopub object based on given assertion, with given assertion and (defrag'd) URI.
+        Any blank nodes in the rdf graph are replaced with the nanopub's URI, with the blank node name
+        as a fragment. For example, if the blank node is called 'step', that would result in a URI composed of the
+        nanopub's (base) URI, followed by #step.
+
+        If introduces_concept is given (string, or rdflib.URIRef), the pubinfo graph will note that this nanopub npx:introduces the given URI.
+        If a blank node (rdflib.term.BNode) is given instead of a URI, the blank node will be converted to a URI
+        derived from the nanopub's URI with a fragment (#) made from the blank node's name.
+
+        If derived_from is given (string or rdflib.URIRef), the provenance graph will note that this nanopub prov:wasDerivedFrom the given URI.
+
+        If attributed_to is given (string or rdflib.URIRef), the provenance graph will note that this nanopub prov:wasAttributedTo the given URI.
+
+        if nanopub_author is given (string or rdflib.URIRef), the pubinfo graph will note that this nanopub prov:wasAttributedTo the given URI.
+
+        """
+
+        # Make sure passed URI is defrag'd
+        uri = str(uri)
+        uri, _ = urldefrag(uri)
+        this_np = rdflib.Namespace(uri + '#')
+
+        # Replace any blank nodes in the supplied RDF, with a URI derived from the nanopub's uri.
+        # 'Blank nodes' here refers specifically to rdflib.term.BNode objects.
+        # For example, if the nanopub's URI is www.purl.org/ABC123 then the blank node will be replaced with a
+        # concrete URIRef of the form www.purl.org/ABC123#blanknodename where 'blanknodename' is the name of the
+        # the rdflib.term.BNode object. If blanknodename is 'step', then the URI will have a fragment '#step' after it.
+        #
+        # The problem that this is designed to solve is that a user may wish to use the nanopublication to introduce
+        # a new concept. This new concept needs its own URI (it cannot simply be given the nanopublication's URI),
+        # but it should still lie within the space of the nanopub. Furthermore, the URI the nanopub is published
+        # is not known ahead of time. The variable 'this_np', for example, is holding a dummy URI that is swapped
+        # with the true, published URI of the nanopub by the 'np' tool at the moment of publication.
+        #
+        # We wish to replace any blank nodes in the rdf with URIs that are based on this same dummy URI, so that
+        # they too are transformed to the correct URI upon publishing.
+        for s, p, o in assertion_rdf:
+            assertion_rdf.remove((s, p, o))
+            if isinstance(s, rdflib.term.BNode):
+                s = this_np[str(s)]
+            if isinstance(o, rdflib.term.BNode):
+                o = this_np[str(o)]
+            assertion_rdf.add((s, p, o))
+
+        # Set up different contexts
+        rdf = rdflib.ConjunctiveGraph()
+        head = rdflib.Graph(rdf.store, this_np.Head)
+        assertion = rdflib.Graph(rdf.store, this_np.assertion)
+        provenance = rdflib.Graph(rdf.store, this_np.provenance)
+        pub_info = rdflib.Graph(rdf.store, this_np.pubInfo)
+
+        rdf.bind("", this_np)
+        rdf.bind("np", namespaces.NP)
+        rdf.bind("npx", namespaces.NPX)
+        rdf.bind("p-plan", namespaces.PPLAN)
+        rdf.bind("prov", namespaces.PROV)
+        rdf.bind("dul", namespaces.DUL)
+        rdf.bind("bpmn", namespaces.BPMN)
+        rdf.bind("pwo", namespaces.PWO)
+        rdf.bind("hycl", namespaces.HYCL)
+        rdf.bind("dc", DC)
+        rdf.bind("dcterms", DCTERMS)
+
+        head.add((this_np[''], RDF.type, namespaces.NP.Nanopublication))
+        head.add((this_np[''], namespaces.NP.hasAssertion, this_np.assertion))
+        head.add((this_np[''], namespaces.NP.hasProvenance, this_np.provenance))
+        head.add((this_np[''], namespaces.NP.hasPublicationInfo,
+                  this_np.pubInfo))
+
+        assertion += assertion_rdf
+
+        creationtime = rdflib.Literal(datetime.now(), datatype=XSD.dateTime)
+        provenance.add((this_np.assertion, namespaces.PROV.generatedAtTime, creationtime))
+
+        pub_info.add((this_np[''], namespaces.PROV.generatedAtTime, creationtime))
+
+        if attributed_to:
+            attributed_to = rdflib.URIRef(attributed_to)
+            provenance.add((this_np.assertion,
+                            namespaces.PROV.wasAttributedTo,
+                            attributed_to))
+
+        if derived_from:
+            # Convert derived_from URI to an rdflib term first (if necessary)
+            derived_from = rdflib.URIRef(derived_from)
+
+            provenance.add((this_np.assertion,
+                            namespaces.PROV.wasDerivedFrom,
+                            derived_from))
+
+        if nanopub_author:
+            nanopub_author = rdflib.URIRef(nanopub_author)
+            pub_info.add((this_np[''],
+                          namespaces.PROV.wasAttributedTo,
+                          nanopub_author))
+
+        if introduces_concept:
+            # Convert introduces_concept URI to an rdflib term first (if necessary)
+            if isinstance(introduces_concept, rdflib.term.BNode):
+                introduces_concept = this_np[str(introduces_concept)]
+            else:
+                introduces_concept = rdflib.URIRef(introduces_concept)
+
+            pub_info.add((this_np[''],
+                          namespaces.NPX.introduces,
+                          introduces_concept))
+
+        obj = cls(rdf=rdf, source_uri=uri)
+        obj._introduces_concept = introduces_concept
+        return obj
+
+    @property
+    def rdf(self):
+        return self._rdf
+
+    @property
+    def assertion(self):
+        return self._graphs['assertion']
+
+    @property
+    def pubinfo(self):
+        return self._graphs['pubinfo']
+
+    @property
+    def provenance(self):
+        return self._graphs['provenance']
+
+    @property
+    def source_uri(self):
+        return self._source_uri
+
+    @property
+    def introduces_concept(self):
+        # TODO: This should eventually look at the pubinfo graph for the
+        #  NPX.introduces predicate.
+        return self._introduces_concept
+
+    def __str__(self):
+        s = f'Original source URI = {self._source_uri}\n'
+        s += self._rdf.serialize(format='trig').decode('utf-8')
+        return s
+
+
 @unique
 class Formats(Enum):
     """
@@ -158,143 +329,18 @@ class NanopubClient:
             nanopub_rdf.parse(data=r.text, format=format)
             return Nanopub(rdf=nanopub_rdf, source_uri=uri)
 
-    @staticmethod
-    def to_rdf(assertionrdf, uri=DEFAULT_URI, introduces_concept=None, derived_from=None, attributed_to=None, nanopub_author=None):
+    def publish(self, nanopub: Nanopub):
         """
-        Return the nanopub rdf, with given assertion and (defrag'd) URI, but does not sign or publish.
-        Any blank nodes in the rdf graph are replaced with the nanopub's URI, with the blank node name
-        as a fragment. For example, if the blank node is called 'step', that would result in a URI composed of the
-        nanopub's (base) URI, followed by #step.
-
-        If introduces_concept is given (string, or rdflib.URIRef), the pubinfo graph will note that this nanopub npx:introduces the given URI.
-        If a blank node (rdflib.term.BNode) is given instead of a URI, the blank node will be converted to a URI
-        derived from the nanopub's URI with a fragment (#) made from the blank node's name.
-
-        If derived_from is given (string or rdflib.URIRef), the provenance graph will note that this nanopub prov:wasDerivedFrom the given URI.
-
-        If attributed_to is given (string or rdflib.URIRef), the provenance graph will note that this nanopub prov:wasAttributedTo the given URI.
-
-        if nanopub_author is given (string or rdflib.URIRef), the pubinfo graph will note that this nanopub prov:wasAttributedTo the given URI.
-
-        """
-
-        # Make sure passed URI is defrag'd
-        uri = str(uri)
-        uri, _ = urldefrag(uri)
-        this_np = rdflib.Namespace(uri+'#')
-
-        # Replace any blank nodes in the supplied RDF, with a URI derived from the nanopub's uri.
-        # 'Blank nodes' here refers specifically to rdflib.term.BNode objects.
-        # For example, if the nanopub's URI is www.purl.org/ABC123 then the blank node will be replaced with a
-        # concrete URIRef of the form www.purl.org/ABC123#blanknodename where 'blanknodename' is the name of the
-        # the rdflib.term.BNode object. If blanknodename is 'step', then the URI will have a fragment '#step' after it.
-        #
-        # The problem that this is designed to solve is that a user may wish to use the nanopublication to introduce
-        # a new concept. This new concept needs its own URI (it cannot simply be given the nanopublication's URI),
-        # but it should still lie within the space of the nanopub. Furthermore, the URI the nanopub is published
-        # is not known ahead of time. The variable 'this_np', for example, is holding a dummy URI that is swapped
-        # with the true, published URI of the nanopub by the 'np' tool at the moment of publication.
-        #
-        # We wish to replace any blank nodes in the rdf with URIs that are based on this same dummy URI, so that
-        # they too are transformed to the correct URI upon publishing.
-        for s, p, o in assertionrdf:
-            assertionrdf.remove((s, p, o))
-            if isinstance(s, rdflib.term.BNode):
-                s = this_np[str(s)]
-            if isinstance(o, rdflib.term.BNode):
-                o = this_np[str(o)]
-            assertionrdf.add((s, p, o))
-
-        # Set up different contexts
-        np_rdf = rdflib.ConjunctiveGraph()
-        head = rdflib.Graph(np_rdf.store, this_np.Head)
-        assertion = rdflib.Graph(np_rdf.store, this_np.assertion)
-        provenance = rdflib.Graph(np_rdf.store, this_np.provenance)
-        pub_info = rdflib.Graph(np_rdf.store, this_np.pubInfo)
-
-        np_rdf.bind("", this_np)
-        np_rdf.bind("np", namespaces.NP)
-        np_rdf.bind("npx", namespaces.NPX)
-        np_rdf.bind("p-plan", namespaces.PPLAN)
-        np_rdf.bind("prov", namespaces.PROV)
-        np_rdf.bind("dul", namespaces.DUL)
-        np_rdf.bind("bpmn", namespaces.BPMN)
-        np_rdf.bind("pwo", namespaces.PWO)
-        np_rdf.bind("hycl", namespaces.HYCL)
-        np_rdf.bind("dc", DC)
-        np_rdf.bind("dcterms", DCTERMS)
-
-        head.add((this_np[''], RDF.type, namespaces.NP.Nanopublication))
-        head.add((this_np[''], namespaces.NP.hasAssertion, this_np.assertion))
-        head.add((this_np[''], namespaces.NP.hasProvenance, this_np.provenance))
-        head.add((this_np[''], namespaces.NP.hasPublicationInfo,
-                  this_np.pubInfo))
-
-        assertion += assertionrdf
-
-        creationtime = rdflib.Literal(datetime.now(),datatype=XSD.dateTime)
-        provenance.add((this_np.assertion, namespaces.PROV.generatedAtTime, creationtime))
-
-        pub_info.add((this_np[''],namespaces.PROV.generatedAtTime, creationtime))
-
-        if attributed_to:
-            attributed_to = rdflib.URIRef(attributed_to)
-            provenance.add((this_np.assertion,
-                            namespaces.PROV.wasAttributedTo,
-                            attributed_to))
-
-        if derived_from:
-            # Convert derived_from URI to an rdflib term first (if necessary)
-            derived_from = rdflib.URIRef(derived_from)
-
-            provenance.add((this_np.assertion,
-                            namespaces.PROV.wasDerivedFrom,
-                            derived_from))
-
-        if nanopub_author:
-            nanopub_author = rdflib.URIRef(nanopub_author)
-            pub_info.add((this_np[''],
-                         namespaces.PROV.wasAttributedTo,
-                         nanopub_author))
-
-        if introduces_concept:
-            # Convert introduces_concept URI to an rdflib term first (if necessary)
-            if isinstance(introduces_concept, rdflib.term.BNode):
-                introduces_concept = this_np[str(introduces_concept)]
-            else:
-                introduces_concept = rdflib.URIRef(introduces_concept)
-
-            pub_info.add((this_np[''],
-                         namespaces.NPX.introduces,
-                         introduces_concept))
-
-        return np_rdf
-
-    @staticmethod
-    def publish(self, assertionrdf, uri=None, introduces_concept=None, derived_from=None,
-                attributed_to=None, nanopub_author=None):
-        """
-        Publish the given assertion as a nanopublication with the given URI.
+        Publish nanopub object.
         Uses np commandline tool to sign and publish.
-
-        The meanings and usage of uri, introduces_concept, derived_from, attributed_to, and nanopub_author are the same as described for the to_rdf()
-        method in this module.
         """
-
-        np_rdf = self.to_rdf(assertionrdf=assertionrdf,
-                             uri=uri,
-                             introduces_concept=introduces_concept,
-                             derived_from=derived_from,
-                             attributed_to=attributed_to,
-                             nanopub_author=nanopub_author)
-
         # Create a temporary dir for files created during serializing and signing
         tempdir = tempfile.mkdtemp()
 
         # Convert nanopub rdf to trig
         fname = 'temp.trig'
         unsigned_fname = os.path.join(tempdir, fname)
-        serialized = np_rdf.serialize(destination=unsigned_fname, format='trig')
+        nanopub.rdf.serialize(destination=unsigned_fname, format='trig')
 
         # Sign the nanopub and publish it
         signed_file = java_wrapper.sign(unsigned_fname)
@@ -302,15 +348,15 @@ class NanopubClient:
         publication_info = {'nanopub_uri': nanopub_uri}
         print(f'Published to {nanopub_uri}')
 
-        if introduces_concept:
+        if nanopub.introduces_concept:
             # Construct the (actually published) URI of the concept being introduced by this nanopub.
             # This is only necessary if a blank node was passed as introduces_concept. In that case
-            # this module's to_rdf() function replaces the blank node with the base nanopub's URI
+            # the Nanopub.from_assertion method replaces the blank node with the base nanopub's URI
             # and appends a fragment, given by the 'name' of the blank node. For example, if a blank node
             # with name 'step' was passed as introduces_concept, the concept will be published with a URI
             # that looks like [published nanopub URI]#step.
 
-            concept_uri = nanopub_uri + '#' + str(introduces_concept)
+            concept_uri = nanopub_uri + '#' + str(nanopub.introduces_concept)
             publication_info['concept_uri'] = concept_uri
             print(f'Published concept to {concept_uri}')
 
@@ -320,57 +366,12 @@ class NanopubClient:
         """
         Publishes a claim, either as a plain text statement, or as an rdf triple (or both)
         """
-        assertionrdf = rdflib.Graph()
+        assertion_rdf = rdflib.Graph()
 
-        assertionrdf.add((namespaces.AUTHOR.DrBob, namespaces.HYCL.claims, rdflib.Literal(text)))
+        assertion_rdf.add((namespaces.AUTHOR.DrBob, namespaces.HYCL.claims, rdflib.Literal(text)))
 
         if rdftriple is not None:
-            assertionrdf.add(rdftriple)
+            assertion_rdf.add(rdftriple)
 
-        self.publish(assertionrdf)
-
-
-class Nanopub:
-    """
-    Stores the rdf parsed from nanopubs from the nanopub servers etc.
-    """
-    def __init__(self, rdf=None, source_uri=None):
-        self._rdf = rdf
-        self._source_uri = source_uri
-
-        # Extract the Head, pubinfo, provenance and assertion graphs from the assigned nanopub rdf
-        self._graphs = {}
-        for c in rdf.contexts():
-            graphid = urldefrag(c.identifier).fragment.lower()
-            self._graphs[graphid] = c
-
-        # Check all four expected graphs are provided
-        expected_graphs = ['head', 'pubinfo', 'provenance', 'assertion']
-        for expected in expected_graphs:
-            if expected not in self._graphs.keys():
-                raise ValueError(f'Expected to find {expected} graph in nanopub rdf, but not found. Graphs found: {list(self._graphs.keys())}.')
-
-    @property
-    def rdf(self):
-        return self._rdf
-
-    @property
-    def assertion(self):
-        return self._graphs['assertion']
-
-    @property
-    def pubinfo(self):
-        return self._graphs['pubinfo']
-
-    @property
-    def provenance(self):
-        return self._graphs['provenance']
-
-    @property
-    def source_uri(self):
-        return self._source_uri
-
-    def __str__(self):
-        s = f'Original source URI = {self._source_uri}\n'
-        s += self._rdf.serialize(format='trig').decode('utf-8')
-        return s
+        nanopub = Nanopub.from_assertion(assertion_rdf=assertion_rdf)
+        self.publish(nanopub)

--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -14,11 +14,11 @@ DEFAULT_URI = 'http://purl.org/nanopub/temp/mynanopub'
 
 
 @unique
-class Format(Enum):
+class Formats(Enum):
     """
     Enums to specify the format of nanopub desired
     """
-    TRIG = 1
+    TRIG = 'trig'
 
 
 class NanopubClient:
@@ -136,24 +136,26 @@ class NanopubClient:
             return[{'Error': f'Error when searching {apiurl}: Status code {r.status_code}'}]
 
     @staticmethod
-    def fetch(uri, format=Format.TRIG):
+    def fetch(uri, format: str = 'trig'):
         """
-        Download the nanopublication at the specified URI (in specified format). If successful, returns a Nanopub object.
+        Download the nanopublication at the specified URI (in specified format).
+
+        Returns:
+            a Nanopub object.
         """
 
-        extension = ''
-        if format == Format.TRIG:
+        if format == Formats.TRIG.value:
             extension = '.trig'
-            parse_format = 'trig'
         else:
-            raise ValueError(f'Format not supported: {format}')
+            raise ValueError(f'Format not supported: {format}, choose from '
+                             f'{[format.value for format in Formats]})')
 
         r = requests.get(uri + extension)
         r.raise_for_status()
 
         if r.ok:
             nanopub_rdf = rdflib.ConjunctiveGraph()
-            nanopub_rdf.parse(data=r.text, format=parse_format)
+            nanopub_rdf.parse(data=r.text, format=format)
             return Nanopub(rdf=nanopub_rdf, source_uri=uri)
 
     @staticmethod

--- a/tests/test_nanopub.py
+++ b/tests/test_nanopub.py
@@ -105,7 +105,7 @@ def test_nanopub_fetch():
     ]
 
     for np_uri in known_nps:
-        np = client.fetch(np_uri)
+        np = client.fetch(np_uri, format='trig')
         assert isinstance(np, Nanopub)
         assert np.source_uri == np_uri
         assert len(np.rdf) > 0

--- a/tests/test_nanopub.py
+++ b/tests/test_nanopub.py
@@ -115,35 +115,33 @@ def test_nanopub_fetch():
         assert len(np.__str__()) > 0
 
 
-def test_nanopub_rdf():
+def test_nanopub_from_assertion():
     """
-    Test that Nanopub.to_rdf() is creating an rdf graph with the right features (contexts)
+    Test that Nanopub.from_assertion is creating an rdf graph with the right features (contexts)
     for a nanopub.
     """
-    client = NanopubClient()
+    assertion_rdf = rdflib.Graph()
+    assertion_rdf.add((namespaces.AUTHOR.DrBob, namespaces.HYCL.claims,
+                       rdflib.Literal('This is a test')))
 
-    assertionrdf = rdflib.Graph()
-    assertionrdf.add((namespaces.AUTHOR.DrBob, namespaces.HYCL.claims, rdflib.Literal('This is a '
-                                                                                     'test')))
+    nanopub = Nanopub.from_assertion(assertion_rdf)
 
-    generated_rdf = client.to_rdf(assertionrdf)
-
-    assert generated_rdf is not None
-    assert (None, RDF.type, namespaces.NP.Nanopublication) in generated_rdf
-    assert (None, namespaces.NP.hasAssertion, None) in generated_rdf
-    assert (None, namespaces.NP.hasProvenance, None) in generated_rdf
-    assert (None, namespaces.NP.hasPublicationInfo, None) in generated_rdf
+    assert nanopub.rdf is not None
+    assert (None, RDF.type, namespaces.NP.Nanopublication) in nanopub.rdf
+    assert (None, namespaces.NP.hasAssertion, None) in nanopub.rdf
+    assert (None, namespaces.NP.hasProvenance, None) in nanopub.rdf
+    assert (None, namespaces.NP.hasPublicationInfo, None) in nanopub.rdf
 
     new_concept = rdflib.term.URIRef('www.purl.org/new/concept/test')
-    generated_rdf = client.to_rdf(assertionrdf, introduces_concept=new_concept)
+    nanopub = Nanopub.from_assertion(assertion_rdf, introduces_concept=new_concept)
 
-    assert generated_rdf is not None
-    assert (None, RDF.type, namespaces.NP.Nanopublication) in generated_rdf
-    assert (None, namespaces.NP.hasAssertion, None) in generated_rdf
-    assert (None, namespaces.NP.hasProvenance, None) in generated_rdf
-    assert (None, namespaces.NP.hasPublicationInfo, None) in generated_rdf
+    assert nanopub.rdf is not None
+    assert (None, RDF.type, namespaces.NP.Nanopublication) in nanopub.rdf
+    assert (None, namespaces.NP.hasAssertion, None) in nanopub.rdf
+    assert (None, namespaces.NP.hasProvenance, None) in nanopub.rdf
+    assert (None, namespaces.NP.hasPublicationInfo, None) in nanopub.rdf
 
-    assert (None, namespaces.NPX.introduces, new_concept) in generated_rdf
+    assert (None, namespaces.NPX.introduces, new_concept) in nanopub.rdf
 
 
 @patch('nanopub.java_wrapper.publish')
@@ -158,10 +156,13 @@ def test_nanopub_claim(java_wrapper_publish_mock):
 @patch('nanopub.java_wrapper.publish')
 def test_nanopub_publish(java_wrapper_publish_mock):
     client = NanopubClient()
-    assertionrdf = rdflib.Graph()
-    assertionrdf.add((namespaces.AUTHOR.DrBob, namespaces.HYCL.claims, rdflib.Literal('This is a test')))
+    assertion_rdf = rdflib.Graph()
+    assertion_rdf.add((namespaces.AUTHOR.DrBob, namespaces.HYCL.claims, rdflib.Literal('This is a test')))
 
-    client.publish(assertionrdf,
-                   uri=rdflib.term.URIRef('http://www.example.com/auri'),
-                   introduces_concept=namespaces.AUTHOR.DrBob,
-                   derived_from=rdflib.term.URIRef('http://www.example.com/someuri'))
+    nanopub = Nanopub.from_assertion(
+        assertion_rdf=assertion_rdf,
+        uri=rdflib.term.URIRef('http://www.example.com/auri'),
+        introduces_concept=namespaces.AUTHOR.DrBob,
+        derived_from=rdflib.term.URIRef('http://www.example.com/someuri')
+        )
+    client.publish(nanopub)


### PR DESCRIPTION
Refactor Nanopub class to NanopubClient, make the class methods into proper methods.
Refactor NanopubObj class to Nanopub.
Move the functionality of the `to_rdf` method to the `from_assertion` classmethod of the new `Nanopub` class.
Move namespaces to a separate namespaces module.

It think there is still a lot to improve, but these are I think the major refactorings that we want to do.