### PR TITLE
Adapt np script to download nanopub-java version 1.32 instead of latest

### DIFF
--- a/nanopub/np
+++ b/nanopub/np
@@ -2,17 +2,12 @@
 
 set -e
 
+NANOPUB_JAVA_VERSION="1.32"
+
 function download-nanopub-jar {
-  >&2 echo "Getting latest nanopub version..."
-  NANOPUB_LATEST_LOCATION=$(
-    curl --head -s https://github.com/Nanopublication/nanopub-java/releases/latest \
-    | egrep -i '^location:'
-  )
-  NANOPUB_VERSION=${NANOPUB_LATEST_LOCATION##*-}
-  NANOPUB_VERSION="${NANOPUB_VERSION%"${NANOPUB_VERSION##*[![:space:]]}"}" 
-  >&2 echo "Downloading nanopub jar file version $NANOPUB_VERSION..."
-  echo "$SCRIPTDIR/nanopub-${NANOPUB_VERSION}-jar-with-dependencies.jar"
-  curl -L --output "$SCRIPTDIR/nanopub-${NANOPUB_VERSION}-jar-with-dependencies.jar" "https://github.com/Nanopublication/nanopub-java/releases/download/nanopub-${NANOPUB_VERSION}/nanopub-${NANOPUB_VERSION}-jar-with-dependencies.jar"
+  >&2 echo "Downloading nanopub jar file version $NANOPUB_JAVA_VERSION..."
+  echo "$SCRIPTDIR/nanopub-${NANOPUB_JAVA_VERSION}-jar-with-dependencies.jar"
+  curl -L --output "$SCRIPTDIR/nanopub-${NANOPUB_JAVA_VERSION}-jar-with-dependencies.jar" "https://github.com/Nanopublication/nanopub-java/releases/download/nanopub-${NANOPUB_JAVA_VERSION}/nanopub-${NANOPUB_JAVA_VERSION}-jar-with-dependencies.jar"
 }
 
 WORKINGDIR=`pwd`


### PR DESCRIPTION
NB: Docker-based solution is undesired, hence this PR. (see discussion on https://github.com/fair-workflows/nanopub/issues/18)