### PR TITLE
Enforce using profile

### DIFF
--- a/nanopub/client.py
+++ b/nanopub/client.py
@@ -269,11 +269,8 @@ class NanopubClient:
             self._check_public_keys_match(uri)
         assertion_rdf = rdflib.Graph()
         orcid_id = profile.get_orcid_id()
-        if orcid_id is None:
-            raise RuntimeError('You need to setup your profile with ORCID iD in order to retract a '
-                               'nanopublication, see the instructions in the README')
         assertion_rdf.add((rdflib.URIRef(orcid_id), namespaces.NPX.retracts,
                            rdflib.URIRef(uri)))
         publication = Publication.from_assertion(assertion_rdf=assertion_rdf,
-                                                 attribute_to_profile=True)
+                                                 attribute_assertion_to_profile=True)
         return self.publish(publication)

--- a/nanopub/client.py
+++ b/nanopub/client.py
@@ -218,7 +218,7 @@ class NanopubClient:
         assertion_rdf.add((this_statement, rdflib.RDFS.label, rdflib.Literal(statement_text)))
 
         publication = Publication.from_assertion(assertion_rdf=assertion_rdf,
-                                                 attribute_to_profile=True)
+                                                 attribute_assertion_to_profile=True)
 
         # TODO: This is a hacky solution, should be changed once we can add provenance triples to
         #  from_assertion method.
@@ -226,9 +226,6 @@ class NanopubClient:
                                     namespaces.HYCL.claims,
                                     rdflib.URIRef(DEFAULT_NANOPUB_URI + '#mystatement')))
         self.publish(publication)
-
-        nanopub = Publication.from_assertion(assertion_rdf=assertion_rdf)
-        self.publish(nanopub)
 
     def _check_public_keys_match(self, uri):
         """ Check for matching public keys of a nanopublication with the profile.

--- a/nanopub/profile.py
+++ b/nanopub/profile.py
@@ -13,8 +13,19 @@ PRIVATE_KEY = 'private_key'
 PROFILE_NANOPUB = 'profile_nanopub'
 
 
+class ProfileError(RuntimeError):
+    """
+    Error to be raised if profile is not setup correctly.
+    """
+    pass
+
+
 def get_orcid_id():
-    return get_profile()[ORCID_ID]
+    orcid_id = get_profile()[ORCID_ID]
+    if not orcid_id:
+        raise ProfileError('Your profile was not setup yet or not setup correctly. To setup '
+                           'your profile see instructions in Readme.md')
+    return orcid_id
 
 
 @lru_cache()

--- a/nanopub/profile.py
+++ b/nanopub/profile.py
@@ -31,7 +31,10 @@ def get_orcid_id():
 def get_public_key():
     filepath = get_profile()[PUBLIC_KEY_FILEPATH]
     with open(filepath, 'r') as f:
-        return f.read()
+        public_key = f.read()
+    if not public_key:
+        raise ProfileError('Your profile was not setup yet or not setup correctly. To setup '
+                           'your profile see instructions in Readme.md')
 
 
 @lru_cache()

--- a/nanopub/publication.py
+++ b/nanopub/publication.py
@@ -33,7 +33,7 @@ class Publication:
     @classmethod
     def from_assertion(cls, assertion_rdf, uri=DEFAULT_NANOPUB_URI, introduces_concept=None,
                        derived_from=None, attributed_to=None,
-                       attribute_to_profile: bool = False, nanopub_author=None):
+                       attribute_to_profile: bool = False):
         """
         Construct Nanopub object based on given assertion, with given assertion and (defrag'd) URI.
         Any blank nodes in the rdf graph are replaced with the nanopub's URI, with the blank node name
@@ -50,15 +50,8 @@ class Publication:
             attributed_to: the provenance graph will note that this nanopub prov:wasAttributedTo
                 the given URI.
             attribute_to_profile: Attribute the nanopub to the ORCID iD in the profile
-            nanopub_author: the pubinfo graph will note that this nanopub prov:wasAttributedTo the
-                given URI. If no nanopub_author is provided we default to the author from the
-                profile
 
         """
-
-        if nanopub_author is None and profile.get_orcid_id() is not None:
-            nanopub_author = rdflib.URIRef(profile.get_orcid_id())
-
         if attributed_to and attribute_to_profile:
             raise ValueError('If you pass a URI for the attributed_to argument, you cannot pass '
                              'attribute_to_profile=True, because the nanopub will already be '
@@ -135,7 +128,7 @@ class Publication:
                 list_of_URIs = derived_from
             else:
                 list_of_URIs = [derived_from]
-           
+
             for derived_from_uri in list_of_URIs:
                 # Convert uri to an rdflib term first (if necessary)
                 derived_from_uri = rdflib.URIRef(derived_from_uri)
@@ -144,11 +137,10 @@ class Publication:
                                 namespaces.PROV.wasDerivedFrom,
                                 derived_from_uri))
 
-        if nanopub_author:
-            nanopub_author = rdflib.URIRef(nanopub_author)
-            pub_info.add((this_np[''],
-                          namespaces.PROV.wasAttributedTo,
-                          nanopub_author))
+        # Always attribute the nanopublication (not the assertion) to the ORCID iD in user profile
+        pub_info.add((this_np[''],
+                      namespaces.PROV.wasAttributedTo,
+                      rdflib.URIRef(profile.get_orcid_id())))
 
         if introduces_concept:
             # Convert introduces_concept URI to an rdflib term first (if necessary)

--- a/nanopub/publication.py
+++ b/nanopub/publication.py
@@ -49,7 +49,7 @@ class Publication:
                           If a list of URIs is passed, a provenance triple will be generated for each.
             assertion_attributed_to: the provenance graph will note that this nanopub's assertion
                 prov:wasAttributedTo the given URI.
-            attribute_assertion_to_profile: Attribute the nanopub to the ORCID iD in the profile
+            attribute_assertion_to_profile: Attribute the assertion to the ORCID iD in the profile
 
         """
         if assertion_attributed_to and attribute_assertion_to_profile:

--- a/nanopub/publication.py
+++ b/nanopub/publication.py
@@ -32,8 +32,8 @@ class Publication:
 
     @classmethod
     def from_assertion(cls, assertion_rdf, uri=DEFAULT_NANOPUB_URI, introduces_concept=None,
-                       derived_from=None, attributed_to=None,
-                       attribute_to_profile: bool = False):
+                       derived_from=None, assertion_attributed_to=None,
+                       attribute_assertion_to_profile: bool = False):
         """
         Construct Nanopub object based on given assertion, with given assertion and (defrag'd) URI.
         Any blank nodes in the rdf graph are replaced with the nanopub's URI, with the blank node name
@@ -47,19 +47,20 @@ class Publication:
         Args:
             derived_from: Add that this nanopub prov:wasDerivedFrom the given URI to the provenance graph.
                           If a list of URIs is passed, a provenance triple will be generated for each.
-            attributed_to: the provenance graph will note that this nanopub prov:wasAttributedTo
-                the given URI.
-            attribute_to_profile: Attribute the nanopub to the ORCID iD in the profile
+            assertion_attributed_to: the provenance graph will note that this nanopub's assertion
+                prov:wasAttributedTo the given URI.
+            attribute_assertion_to_profile: Attribute the nanopub to the ORCID iD in the profile
 
         """
-        if attributed_to and attribute_to_profile:
-            raise ValueError('If you pass a URI for the attributed_to argument, you cannot pass '
-                             'attribute_to_profile=True, because the nanopub will already be '
-                             'attributed to the value passed in attributed_to argument. Set '
-                             'attribute_to_profile=False or do not pass the attributed_to '
-                             'argument.')
-        if attribute_to_profile and profile.get_orcid_id() is not None:
-            attributed_to = rdflib.URIRef(profile.get_orcid_id())
+        if assertion_attributed_to and attribute_assertion_to_profile:
+            raise ValueError(
+                'If you pass a URI for the assertion_attributed_to argument, you cannot pass '
+                'attribute_assertion_to_profile=True, because the assertion will already be '
+                'attributed to the value passed in assertion_attributed_to argument. Set '
+                'attribute_assertion_to_profile=False or do not pass the assertion_attributed_to '
+                'argument.')
+        if attribute_assertion_to_profile:
+            assertion_attributed_to = rdflib.URIRef(profile.get_orcid_id())
 
         # Make sure passed URI is defrag'd
         uri = str(uri)
@@ -116,11 +117,11 @@ class Publication:
 
         pub_info.add((this_np[''], namespaces.PROV.generatedAtTime, creationtime))
 
-        if attributed_to:
-            attributed_to = rdflib.URIRef(attributed_to)
+        if assertion_attributed_to:
+            assertion_attributed_to = rdflib.URIRef(assertion_attributed_to)
             provenance.add((this_np.assertion,
                             namespaces.PROV.wasAttributedTo,
-                            attributed_to))
+                            assertion_attributed_to))
 
         if derived_from:
             uris = []

--- a/nanopub/setup_profile.py
+++ b/nanopub/setup_profile.py
@@ -26,9 +26,7 @@ def validate_orcid_id(ctx, orcid_id: str):
     Check if valid ORCID iD, should be https://orcid.org/ + 16 digit in form:
         https://orcid.org/0000-0000-0000-0000
     """
-    if not orcid_id:
-        return None
-    elif re.match(ORCID_ID_REGEX, orcid_id):
+    if re.match(ORCID_ID_REGEX, orcid_id):
         return orcid_id
     else:
         raise ValueError('Your ORCID iD is not valid, please provide a valid ORCID iD that '
@@ -46,12 +44,9 @@ def validate_orcid_id(ctx, orcid_id: str):
               help='Your RSA public and private keys with which your nanopubs will be signed',
               default=None)
 @click.option('--orcid_id', type=str,
-              prompt='What is your ORCID iD (i.e. https://orcid.org/0000-0000-0000-0000)? '
-                     'Optionally leave empty',
-              help='Your ORCID iD (i.e. https://orcid.org/0000-0000-0000-0000), '
-                   'optionally leave empty',
-              callback=validate_orcid_id,
-              default='')
+              prompt='What is your ORCID iD (i.e. https://orcid.org/0000-0000-0000-0000)?',
+              help='Your ORCID iD (i.e. https://orcid.org/0000-0000-0000-0000)',
+              callback=validate_orcid_id)
 @click.option('--name', type=str, prompt='What is your full name?', help='Your full name')
 @click.option('--publish/--no-publish', type=bool, is_flag=True, default=True,
               help='If true, nanopub will be published to nanopub servers',

--- a/nanopub/setup_profile.py
+++ b/nanopub/setup_profile.py
@@ -104,7 +104,7 @@ def main(orcid_id, publish, name, keypair: Union[Tuple[Path, Path], None]):
     if publish:
         assertion, concept = _create_this_is_me_rdf(orcid_id, public_key, name)
         np = Publication.from_assertion(assertion, introduces_concept=concept, nanopub_author=orcid_id,
-                                        attributed_to=orcid_id)
+                                        assertion_attributed_to=orcid_id)
 
         client = NanopubClient()
         result = client.publish(np)

--- a/nanopub/setup_profile.py
+++ b/nanopub/setup_profile.py
@@ -95,15 +95,16 @@ def main(orcid_id, publish, name, keypair: Union[Tuple[Path, Path], None]):
 
     # Public key can always be found at DEFAULT_PUBLIC_KEY_PATH. Either new keys have been generated there or
     # existing keys have been copy to that location.
-    public_key_path = DEFAULT_PUBLIC_KEY_PATH
-    public_key = public_key_path.read_text()
+    public_key = DEFAULT_PUBLIC_KEY_PATH.read_text()
 
     profile_nanopub_uri = None
+    profile.store_profile(name, orcid_id, DEFAULT_PUBLIC_KEY_PATH, DEFAULT_PRIVATE_KEY_PATH,
+                          profile_nanopub_uri)
 
     # Declare the user to nanopub
     if publish:
         assertion, concept = _create_this_is_me_rdf(orcid_id, public_key, name)
-        np = Publication.from_assertion(assertion, introduces_concept=concept, nanopub_author=orcid_id,
+        np = Publication.from_assertion(assertion, introduces_concept=concept,
                                         assertion_attributed_to=orcid_id)
 
         client = NanopubClient()
@@ -111,9 +112,9 @@ def main(orcid_id, publish, name, keypair: Union[Tuple[Path, Path], None]):
 
         profile_nanopub_uri = result['concept_uri']
 
-    # Keys are always stored or copied to default location
-    profile.store_profile(name, orcid_id, public_key_path, DEFAULT_PRIVATE_KEY_PATH,
-                          profile_nanopub_uri)
+        # Store profile nanopub uri
+        profile.store_profile(name, orcid_id, DEFAULT_PUBLIC_KEY_PATH, DEFAULT_PRIVATE_KEY_PATH,
+                              profile_nanopub_uri)
 
 
 def _delete_keys():

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,11 @@
+from unittest import mock
+
+import pytest
+
+from nanopub import profile
+
+
+@mock.patch('nanopub.profile.get_profile', return_value={'orcid_id': ''})
+def test_no_orcid_id(mock_get_profile):
+    with pytest.raises(profile.ProfileError):
+        profile.get_orcid_id()

--- a/tests/test_publication.py
+++ b/tests/test_publication.py
@@ -24,7 +24,7 @@ class TestPublication:
             uri=rdflib.term.URIRef(test_uri),
             introduces_concept=rdflib.term.BNode('DrBob'),
             derived_from=rdflib.term.URIRef('http://www.example.com/another-nanopub'),
-            attributed_to=TEST_ORCID_ID
+            assertion_attributed_to=TEST_ORCID_ID
         )
         assert str(publication.introduces_concept) == test_concept_uri
 
@@ -43,7 +43,7 @@ class TestPublication:
             assertion_rdf=assertion_rdf,
             uri=rdflib.term.URIRef(test_uri),
             derived_from=derived_from_list,
-            attributed_to=TEST_ORCID_ID
+            assertion_attributed_to=TEST_ORCID_ID
         )
 
         for uri in derived_from_list:

--- a/tests/test_setup_profile.py
+++ b/tests/test_setup_profile.py
@@ -55,9 +55,8 @@ def test_provided_keypair_copied_to_nanopub_dir(tmp_path: Path):
 
 
 def test_validate_orcid_id():
-    valid_ids = ['https://orcid.org/1234-5678-1234-5678', '']
-    for orcid_id in valid_ids:
-        validate_orcid_id(ctx=None, orcid_id=orcid_id)
+    valid_id = 'https://orcid.org/1234-5678-1234-5678'
+    assert validate_orcid_id(ctx=None, orcid_id=valid_id) == valid_id
     invalid_ids = ['https://orcid.org/abcd-efgh-abcd-efgh',
                    'https://orcid.org/1234-5678-1234-567',
                    'https://orcid.org/1234-5678-1234-56789',

--- a/tests/test_setup_profile.py
+++ b/tests/test_setup_profile.py
@@ -60,7 +60,8 @@ def test_validate_orcid_id():
     invalid_ids = ['https://orcid.org/abcd-efgh-abcd-efgh',
                    'https://orcid.org/1234-5678-1234-567',
                    'https://orcid.org/1234-5678-1234-56789',
-                   'https://other-url.org/1234-5678-1234-5678']
+                   'https://other-url.org/1234-5678-1234-5678',
+                   '0000-0000-0000-0000']
     for orcid_id in invalid_ids:
         with pytest.raises(ValueError):
             validate_orcid_id(ctx=None, orcid_id=orcid_id)


### PR DESCRIPTION
- [x] Get rid of `nanopub_author`, always use profile. If people want to have a different orcid id as nanopub author they should rerun setup_profile.
- [x] If there's no orcid id in profile or no profile raise error and point to setup_profile
- [x] Enforce setting a valid orcid_id in setup_profile
- [x] Rename `attributed_to` to `assertion_attributed_to` 
- [x] Rename`attribute_to_profile` to `attribute_assertion_to_profile`