### PR TITLE
Fix link to what are nanopubs documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Not released]
+
+### Fixed
+* Fixed broken link to documentation in README.md
+
 ## [1.0.0] - 2020-12-08
 
 NB: All changes before [1.0.0] are collapsed in here (even though there were multiple pre-releases)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 The ```nanopub``` library provides a high-level, user-friendly python interface for searching, publishing and retracting nanopublications.
 
 Nanopublications are a formalized and machine-readable way of communicating
-the smallest possible units of publishable information. See [the documentation](https://nanopub.readthedocs.io/en/latest/what-are-nanopubs.html)
+the smallest possible units of publishable information. See [the documentation](https://nanopub.readthedocs.io/en/latest/getting-started/what-are-nanopubs.html)
 for more information.
 
 # Documentation


### PR DESCRIPTION
Fixes #86 