### PR TITLE
Catch FileNotFoundError when profile file does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Not released]
+### Changed
+* Improved error message by pointing to documentation instead of Readme upon ProfileErrors
+### Fixed
+* Catch FileNotFoundError when profile.yml does not exist, raise ProfileError with useful messageinstead.
+
 ## [1.0.0] - 2020-12-08
 
 NB: All changes before [1.0.0] are collapsed in here (even though there were multiple pre-releases)

--- a/nanopub/java_wrapper.py
+++ b/nanopub/java_wrapper.py
@@ -7,6 +7,8 @@ import requests
 
 from nanopub.definitions import PKG_FILEPATH
 
+from nanopub.profile import PROFILE_INSTRUCTIONS_MESSAGE
+
 # Location of nanopub tool (currently shipped along with the lib)
 NANOPUB_SCRIPT = str(PKG_FILEPATH / 'np')
 NANOPUB_TEST_SERVER = 'http://test-server.nanopubs.lod.labs.vu.nl/'
@@ -32,8 +34,8 @@ class JavaWrapper:
         rsa_key_messages = ['FileNotFoundException', 'id_rsa']
         stderr = result.stderr.decode('utf8')
         if all(m in stderr for m in rsa_key_messages):
-            raise RuntimeError('RSA key appears to be missing, see the instructions for making RSA'
-                               'keys in the setup section of the README')
+            raise RuntimeError('Nanopub RSA key appears to be missing,\n'
+                               + PROFILE_INSTRUCTIONS_MESSAGE)
         elif result.returncode != 0:
             raise RuntimeError(f'Error in nanopub java application: {stderr}')
 

--- a/nanopub/profile.py
+++ b/nanopub/profile.py
@@ -6,6 +6,11 @@ import yatiml
 
 from nanopub.definitions import PROFILE_PATH
 
+PROFILE_INSTRUCTIONS_MESSAGE = '''
+    Follow these instructions to correctly setup your nanopub profile:
+    https://nanopub.readthedocs.io/en/latest/getting-started/setup.html#setup-your-profile
+'''
+
 
 class ProfileError(RuntimeError):
     """
@@ -56,9 +61,9 @@ def get_public_key() -> str:
         with open(get_profile().public_key, 'r') as f:
             return f.read()
     except FileNotFoundError:
-        raise ProfileError(f'Public key file {get_profile().public_key} not found.\n'
-                           'Maybe your profile was not set up yet or not set up correctly. '
-                           'To set up your profile see the instructions in Readme.md')
+        raise ProfileError(f'Public key file {get_profile().public_key} for nanopub not found.\n'
+                           f'Maybe your nanopub profile was not set up yet or not set up '
+                           f'correctly. \n{PROFILE_INSTRUCTIONS_MESSAGE}')
 
 
 @lru_cache()
@@ -76,8 +81,8 @@ def get_profile() -> Profile:
     try:
         return _load_profile(PROFILE_PATH)
     except (yatiml.RecognitionError, FileNotFoundError) as e:
-        msg = (f'{e}\nYour profile has not been set up yet, or is not set up correctly. To set'
-               f' up your profile, see the instructions in README.md.')
+        msg = (f'{e}\nYour nanopub profile has not been set up yet, or is not set up correctly.\n'
+               f'{PROFILE_INSTRUCTIONS_MESSAGE}')
         raise ProfileError(msg)
 
 

--- a/nanopub/profile.py
+++ b/nanopub/profile.py
@@ -75,7 +75,7 @@ def get_profile() -> Profile:
     """
     try:
         return _load_profile(PROFILE_PATH)
-    except yatiml.RecognitionError as e:
+    except (yatiml.RecognitionError, FileNotFoundError) as e:
         msg = (f'{e}\nYour profile has not been set up yet, or is not set up correctly. To set'
                f' up your profile, see the instructions in README.md.')
         raise ProfileError(msg)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -38,6 +38,15 @@ def test_fail_loading_incomplete_profile(tmpdir):
             profile.get_profile()
 
 
+def test_profile_file_not_found(tmpdir):
+    test_file = Path(tmpdir / 'profile.yml')
+    with mock.patch('nanopub.profile.PROFILE_PATH', test_file):
+        profile.get_profile.cache_clear()
+
+        with pytest.raises(profile.ProfileError):
+            profile.get_profile()
+
+
 def test_store_profile(tmpdir):
     test_file = Path(tmpdir / 'profile.yml')
 


### PR DESCRIPTION
* Fixes #87 
* Also improves error message by pointing to documentation instead of Readme
