### PR TITLE
Expand functionality on knowing about retractions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Not released]
 ### Added
-* Added `find_valid_signed_nanopubs_with_text` method to NanopubClient
-* Added `find_valid_signed_nanopubs_with_pattern` method to Nanopubclient
-* Added `find_valid_signed_things` method to NanopubClient
+* `pubkey` option to methods of `NanopubClient` that allows searching for publications 
+    signed with the given pubkey. For these methods:
+    - `find_nanopubs_with_text`
+    - `find_nanopubs_with_pattern`
+    - `find_things`
+* `filter_retracted` option to methods of `NanopubClient` that allows searching for publications 
+    that are note retracted. For these methods:
+    - `find_nanopubs_with_text`
+    - `find_nanopubs_with_pattern`
+    - `find_things`
+* `NanopubClient.find_retractions_of` method to search retractions of a given nanopublication.
+* `Publication.signed_with_public_key` property: the public key that the publication was signed with.
 
 ## [1.0.0] - 2020-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Not released]
 
-### Changed
-* Improved error message by pointing to documentation instead of Readme upon ProfileErrors
-
-### Fixed
-* Catch FileNotFoundError when profile.yml does not exist, raise ProfileError with useful messageinstead.
-* Fixed broken link to documentation in README.md
-
 ### Added
 * `pubkey` option to methods of `NanopubClient` that allows searching for publications 
     signed with the given pubkey. For these methods:
@@ -27,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `NanopubClient.find_retractions_of` method to search retractions of a given nanopublication.
 * `Publication.signed_with_public_key` property: the public key that the publication was signed with.
 * `Publication.is_test_publication` property: denoting whether this is a publicaion on the test server.
+
+### Changed
+* Improved error message by pointing to documentation instead of Readme upon ProfileErrors
+
+### Fixed
+* Catch FileNotFoundError when profile.yml does not exist, raise ProfileError with useful messageinstead.
+* Fixed broken link to documentation in README.md
 
 ## [1.0.0] - 2020-12-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `find_things`
 * `NanopubClient.find_retractions_of` method to search retractions of a given nanopublication.
 * `Publication.signed_with_public_key` property: the public key that the publication was signed with.
+* `Publication.is_test_publication` property: denoting whether this is a publicaion on the test server.
 
 ## [1.0.0] - 2020-12-08
 

--- a/docs/publishing/retraction.md
+++ b/docs/publishing/retraction.md
@@ -21,6 +21,9 @@ sub:assertion {
     <https://orcid.org/0000-0000-0000-0000> npx:retracts <http://purl.org/np/RAfk_zBYDerxd6ipfv8fAcQHEzgZcVylMTEkiLlMzsgwQ> .
 }
 ```
+By default nanopublications that have a valid retraction do not show up in search results.
+A valid retraction is a retraction that is signed with the same public key as 
+the nanopublication that it retracts.
 
 ## Retracting a nanopublication that is not yours
 By default we do not retract nanopublications that are not yours (i.e. signed with another public key). 
@@ -55,4 +58,18 @@ AssertionError: The public key in your profile does not match the public keythat
 We can use force=True to override this behavior:
 ```python
 client.retract(not_my_nanopub_uri, force=True)
+```
+
+## Find retractions of a given nanopublication
+You can find out whether a given publication is retracted 
+and what the nanopublications are that retract it using `NanopubClient.find_retractions_of`:
+```python
+>>> from nanopub import NanopubClient
+>>> client = NanopubClient(use_test_server=True)
+>>> # This URI has 1 retraction:
+>>> client.find_retractions_of('http://purl.org/np/RAirauh-vy5f7UJEMTm08C5bh5pnWD-abb-qk3fPYWCzc')
+['http://purl.org/np/RADjlGIB8Vqt7NbG1kqzw-4aIV_k7nyIRirMhPKEYVSlc']
+>>> # This URI has no retractions
+>>>client.find_retractions_of('http://purl.org/np/RAeMfoa6I05zoUmK6sRypCIy3wIpTgS8gkum7vdfOamn8')
+[]
 ```

--- a/docs/searching.md
+++ b/docs/searching.md
@@ -41,7 +41,7 @@ Each dict has the following key-value pairs:
 * `description`: A description of the nanopublication that was parsed from the nanopublication RDF.
 * `np`: The URI of the matching nanopublication.
 
-Example results (from `client.find_nanopubs_with_text('fair')`):
+Example results (from `NanopubClient.find_nanopubs_with_text('fair')`):
 ```python
 [{'date': '2020-05-01T08:05:25.575Z',
   'description': 'The primary objective of the VODAN Implementation Network is '
@@ -53,3 +53,29 @@ Example results (from `client.find_nanopubs_with_text('fair')`):
   'np': 'http://purl.org/np/RAPE0A-NrIZDeX3pvFJr0uHshocfXuUj8n_J3BkY0sMuU'}]
 ```
 
+## Returning retracted publications in search
+By default nanopublications that have a valid retraction do not show up in search results.
+A valid retraction is a retraction that is signed with the same public key as 
+the nanopublication that it retracts. 
+You can toggle this behavior with the `filter_retracted` parameter,
+here is an example with `NanopubClient.find_nanopubs_with_text`:
+```python
+from nanopub import NanopubClient
+client = NanopubClient()
+# Search for nanopublications containing the text fair, also returning retracted publications.
+results = client.find_nanopubs_with_text('fair', filter_retracted=False)
+```
+
+## Filtering search results for a particular publication key
+You can filter search results to publications that are signed with
+a specific publication key (effectively filtering on publications from a single author).
+You use the `pubkey` argument for that. 
+Here is an example with `NanopubClient.find_nanopubs_with_text`:
+```python
+from nanopub import NanopubClient, profile
+# Search for nanopublications containing the text 'test',
+# filtering on publications signed with my publication key.
+client = NanopubClient(use_test_server=True)
+my_public_key = profile.get_public_key()
+results = client.find_nanopubs_with_text('test', pubkey=my_public_key)
+```

--- a/examples/publishing_and_retracting.ipynb
+++ b/examples/publishing_and_retracting.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -20,36 +20,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create the client, that allows searching, fetching and publishing nanopubs\n",
+    "client = NanopubClient(use_test_server=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/svenvanderburg/projects/fair-workflows/nanopub/nanopub/profile.py:51: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.\n",
-      "  return yaml.load(f)\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Published to http://purl.org/np/RAcTwW_JdTqZJTXA4jUTFUj6ut8OI9AqaPb1IBPsLsy-o\n"
+      "Published to http://purl.org/np/RAirauh-vy5f7UJEMTm08C5bh5pnWD-abb-qk3fPYWCzc\n"
      ]
     }
    ],
    "source": [
-    "# Create the client, that allows searching, fetching and publishing nanopubs\n",
-    "client = NanopubClient(use_test_server=True)\n",
-    "\n",
     "# Quickly publish a statement to the server\n",
     "pubinfo = client.claim('All cats are gray')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -68,7 +67,7 @@
      "text": [
       "@prefix hycl: <http://purl.org/petapico/o/hycl#> .\n",
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
-      "@prefix sub: <http://purl.org/np/RAcTwW_JdTqZJTXA4jUTFUj6ut8OI9AqaPb1IBPsLsy-o#> .\n",
+      "@prefix sub: <http://purl.org/np/RAeMfoa6I05zoUmK6sRypCIy3wIpTgS8gkum7vdfOamn8#> .\n",
       "\n",
       "sub:assertion {\n",
       "    sub:mystatement a hycl:Statement ;\n",
@@ -86,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -95,11 +94,11 @@
      "text": [
       "@prefix hycl: <http://purl.org/petapico/o/hycl#> .\n",
       "@prefix prov: <http://www.w3.org/ns/prov#> .\n",
-      "@prefix sub: <http://purl.org/np/RAcTwW_JdTqZJTXA4jUTFUj6ut8OI9AqaPb1IBPsLsy-o#> .\n",
+      "@prefix sub: <http://purl.org/np/RAeMfoa6I05zoUmK6sRypCIy3wIpTgS8gkum7vdfOamn8#> .\n",
       "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
       "\n",
       "sub:provenance {\n",
-      "    sub:assertion prov:generatedAtTime \"2020-11-30T09:44:38.809739\"^^xsd:dateTime ;\n",
+      "    sub:assertion prov:generatedAtTime \"2020-12-14T14:34:08.614483\"^^xsd:dateTime ;\n",
       "        prov:wasAttributedTo <https://orcid.org/0000-0000-0000-0000> .\n",
       "\n",
       "    <https://orcid.org/0000-0000-0000-0000> hycl:claims sub:mystatement .\n",
@@ -254,14 +253,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Published to http://purl.org/np/RAOLg94DSpgPVifZZvhwkJ6NBl558pVXaclrgEYhLpfoI\n"
+      "Published to http://purl.org/np/RADjlGIB8Vqt7NbG1kqzw-4aIV_k7nyIRirMhPKEYVSlc\n"
      ]
     }
    ],
@@ -271,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -289,10 +288,10 @@
      "output_type": "stream",
      "text": [
       "@prefix npx: <http://purl.org/nanopub/x/> .\n",
-      "@prefix sub: <http://purl.org/np/RAOLg94DSpgPVifZZvhwkJ6NBl558pVXaclrgEYhLpfoI#> .\n",
+      "@prefix sub: <http://purl.org/np/RADjlGIB8Vqt7NbG1kqzw-4aIV_k7nyIRirMhPKEYVSlc#> .\n",
       "\n",
       "sub:assertion {\n",
-      "    <https://orcid.org/0000-0000-0000-0000> npx:retracts <http://purl.org/np/RATMPukkNTN19gPFX8WZiU8KTZ3xzxxnC2JNAZFs7e3nQ> .\n",
+      "    <https://orcid.org/0000-0000-0000-0000> npx:retracts <http://purl.org/np/RAirauh-vy5f7UJEMTm08C5bh5pnWD-abb-qk3fPYWCzc> .\n",
       "}\n",
       "\n",
       "\n"
@@ -365,6 +364,55 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Find retractions of a given nanopublication"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['http://purl.org/np/RADjlGIB8Vqt7NbG1kqzw-4aIV_k7nyIRirMhPKEYVSlc']"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# This URI has 1 retraction\n",
+    "client.find_retractions_of('http://purl.org/np/RAirauh-vy5f7UJEMTm08C5bh5pnWD-abb-qk3fPYWCzc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# This URI has no retractions\n",
+    "client.find_retractions_of('http://purl.org/np/RAeMfoa6I05zoUmK6sRypCIy3wIpTgS8gkum7vdfOamn8')"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -374,9 +422,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:fair3.6] *",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-fair3.6-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/searching.ipynb
+++ b/examples/searching.ipynb
@@ -2,12 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pprint import pprint\n",
-    "from nanopub import NanopubClient"
+    "from nanopub import NanopubClient, profile"
    ]
   },
   {
@@ -175,6 +175,45 @@
    "source": [
     "results = client.find_things('http://purl.org/net/p-plan#Step', max_num_results=5)\n",
     "pprint(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nanopub import NanopubClient, profile\n",
+    "# Search for nanopublications containing the text test,\n",
+    "# filtering on publications signed with my publication key.\n",
+    "client = NanopubClient(use_test_server=True)\n",
+    "my_public_key = profile.get_public_key()\n",
+    "results = client.find_nanopubs_with_text('test', pubkey=my_public_key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'np': 'http://purl.org/np/RAwNAVOl2lydH8HqRK9v85Yx2L-T1o6EIuS1KCpEWmDpk',\n",
+       "  'description': 'Test',\n",
+       "  'date': '2020-12-03T15:52:24.167Z'},\n",
+       " {'np': 'http://purl.org/np/RAwNAVOl2lydH8HqRK9v85Yx2L-T1o6EIuS1KCpEWmDpk',\n",
+       "  'description': 'This is a test workflow.',\n",
+       "  'date': '2020-12-03T15:52:24.167Z'}]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results"
    ]
   },
   {

--- a/nanopub/client.py
+++ b/nanopub/client.py
@@ -44,7 +44,8 @@ class NanopubClient:
         else:
             self.grlc_urls = NANOPUB_GRLC_URLS
 
-    def find_nanopubs_with_text(self, text: str, pubkey: str = None, max_num_results: int = 1000):
+    def find_nanopubs_with_text(self, text: str, pubkey: str = None,
+                                filter_retracted: bool = True, max_num_results: int = 1000):
         """Text search.
 
         Search the nanopub servers for any nanopubs matching the
@@ -53,6 +54,8 @@ class NanopubClient:
         Args:
             text (str): The text to search on
             pubkey (str): Public key that the matching nanopubs should be signed with
+            filter_retracted (bool): Toggle filtering for publications that are
+                retracted. Default is True, returning only publications that are not retracted.
             max_num_results (int): Maximum number of result, default = 1000
 
         Returns:
@@ -64,43 +67,19 @@ class NanopubClient:
         """
         if len(text) == 0:
             return []
-        endpoint = 'find_nanopubs_with_text'
+        endpoint = 'find_signed_nanopubs_with_text'
         params = {'text': text, 'graphpred': '', 'month': '', 'day': '', 'year': ''}
         if pubkey:
             params['pubkey'] = pubkey
-            endpoint = 'find_signed_nanopubs_with_text'
+        if filter_retracted:
+            endpoint = 'find_valid_signed_nanopubs_with_text'
         return self._search(endpoint=endpoint,
                             params=params,
                             max_num_results=max_num_results)
 
-    def find_valid_signed_nanopubs_with_text(self, text: str, max_num_results: int = 1000):
-        """Text search in nanopubs that are signed and not retracted.
-
-        Search the nanopub servers for any nanopubs matching the
-        given search text.
-
-        Args:
-            text (str): The text to search on
-            max_num_results (int): Maximum number of result, default = 1000
-
-        Returns:
-            List of dicts depicting matching nanopublications.
-            Each dict holds: 'np': the nanopublication uri,
-            'date': date of creation of the nanopublication,
-            'description': A description of the nanopublication (if found in RDF).
-
-        """
-        if len(text) == 0:
-            return []
-
-        params = {'text': text, 'graphpred': '', 'month': '', 'day': '', 'year': ''}
-
-        return self._search(endpoint='find_valid_signed_nanopubs_with_text',
-                            params=params,
-                            max_num_results=max_num_results)
-
     def find_nanopubs_with_pattern(self, subj: str = None, pred: str = None, obj: str = None,
-                                   pubkey: str = None, max_num_results: int = 1000):
+                                   filter_retracted: bool = True, pubkey: str = None,
+                                   max_num_results: int = 1000):
         """Pattern search.
 
         Search the nanopub servers for any nanopubs matching the given RDF pattern. You can leave
@@ -111,6 +90,8 @@ class NanopubClient:
             pred (str): URI of the predicate that you want to match triples on.
             obj (str): URI of the object that you want to match triples on.
             pubkey (str): Public key that the matching nanopubs should be signed with
+            filter_retracted (bool): Toggle filtering for publications that are
+                retracted. Default is True, returning only publications that are not retracted.
             max_num_results (int): Maximum number of result, default = 1000
 
         Returns:
@@ -121,7 +102,7 @@ class NanopubClient:
 
         """
         params = {}
-        endpoint = 'find_nanopubs_with_pattern'
+        endpoint = 'find_signed_nanopubs_with_pattern'
         if subj:
             params['subj'] = subj
         if pred:
@@ -130,46 +111,15 @@ class NanopubClient:
             params['obj'] = obj
         if pubkey:
             params['pubkey'] = pubkey
-            endpoint = 'find_signed_nanopubs_with_pattern'
+        if filter_retracted:
+            endpoint = 'find_valid_signed_nanopubs_with_pattern'
 
         return self._search(endpoint=endpoint,
                             params=params,
                             max_num_results=max_num_results)
 
-    def find_valid_signed_nanopubs_with_pattern(self, subj: str = None, pred: str = None,
-                                                obj: str = None, max_num_results: int = 1000):
-        """Pattern search in nanopubs that are signed and not retracted.
-
-        Search the nanopub servers for any nanopubs matching the given RDF pattern. You can leave
-        parts of the triple to match anything by not specifying subj, pred, or obj arguments.
-
-        Args:
-            subj (str): URI of the subject that you want to match triples on.
-            pred (str): URI of the predicate that you want to match triples on.
-            obj (str): URI of the object that you want to match triples on.
-            max_num_results (int): Maximum number of result, default = 1000
-
-        Returns:
-            List of dicts depicting matching nanopublications.
-            Each dict holds: 'np': the nanopublication uri,
-            'date': date of creation of the nanopublication,
-            'description': A description of the nanopublication (if found in RDF).
-
-        """
-        params = {}
-        if subj:
-            params['subj'] = subj
-        if pred:
-            params['pred'] = pred
-        if obj:
-            params['obj'] = obj
-
-        return self._search(endpoint='find_valid_signed_nanopubs_with_pattern',
-                            params=params,
-                            max_num_results=max_num_results)
-
     def find_things(self, type: str, searchterm: str = ' ', pubkey: str = None,
-                    max_num_results=1000):
+                    filter_retracted: bool = True, max_num_results=1000):
         """Search things (experimental).
 
         Search for any nanopublications that introduce a concept of the given type, that contain
@@ -179,6 +129,8 @@ class NanopubClient:
             type (str): A URI denoting the type of the introduced concept
             searchterm (str): The term that you want to search on
             pubkey (str): Public key that the matching nanopubs should be signed with
+            filter_retracted (bool): Toggle filtering for publications that are
+                retracted. Default is True, returning only publications that are not retracted.
             max_num_results (int): Maximum number of result, default = 1000
 
         Returns:
@@ -190,45 +142,16 @@ class NanopubClient:
         """
         if searchterm == '':
             raise ValueError(f'Searchterm can not be an empty string: {searchterm}')
-        endpoint = 'find_things'
+        endpoint = 'find_signed_things'
         params = dict()
         params['type'] = type
         params['searchterm'] = searchterm
         if pubkey:
             params['pubkey'] = pubkey
-            endpoint = 'find_signed_things'
+        if filter_retracted:
+            endpoint = 'find_valid_signed_things'
 
         return self._search(endpoint=endpoint,
-                            params=params,
-                            max_num_results=max_num_results)
-
-    def find_valid_signed_things(self, type: str, searchterm: str = ' ',
-                                 max_num_results=1000):
-        """Search things that are signed and not retracted (experimental).
-
-        Search for any nanopublications that introduce a concept of the given type, that contain
-        text with the given search term.
-
-        Args:
-            type (str): A URI denoting the type of the introduced concept
-            searchterm (str): The term that you want to search on
-            max_num_results (int): Maximum number of result, default = 1000
-
-        Returns:
-            List of dicts depicting matching nanopublications.
-            Each dict holds: 'np': the nanopublication uri,
-            'date': date of creation of the nanopublication,
-            'description': A description of the nanopublication (if found in RDF).
-
-        """
-        if searchterm == '':
-            raise ValueError(f'Searchterm can not be an empty string: {searchterm}')
-
-        params = dict()
-        params['type'] = type
-        params['searchterm'] = searchterm
-
-        return self._search(endpoint='find_valid_signed_things',
                             params=params,
                             max_num_results=max_num_results)
 
@@ -255,7 +178,8 @@ class NanopubClient:
 
         results = self.find_nanopubs_with_pattern(pred=namespaces.NPX.retracts,
                                                   obj=rdflib.URIRef(uri),
-                                                  pubkey=public_key)
+                                                  pubkey=public_key,
+                                                  filter_retracted=False)
         return [result['np'] for result in results]
 
     def _query_grlc(self, params, endpoint):

--- a/nanopub/client.py
+++ b/nanopub/client.py
@@ -6,6 +6,7 @@ import os
 import random
 import tempfile
 import warnings
+from typing import List
 
 import rdflib
 import requests
@@ -130,6 +131,18 @@ class NanopubClient:
         return self._search(endpoint='find_things',
                             params=params,
                             max_num_results=max_num_results, )
+
+    def find_retractions_of(self, uri: str) -> List[str]:
+        """Find retractions of given URI
+
+        Find all nanopublications that retract the given URI.
+
+        Returns:
+            List of uris that retract the given URI
+        """
+        results = self.find_nanopubs_with_pattern(pred=namespaces.NPX.retracts,
+                                                  obj=rdflib.URIRef(uri))
+        return [result['np'] for result in results]
 
     def _query_grlc(self, params, endpoint):
         """Query the nanopub server grlc endpoint.

--- a/nanopub/client.py
+++ b/nanopub/client.py
@@ -71,7 +71,7 @@ class NanopubClient:
                             max_num_results=max_num_results)
 
     def find_nanopubs_with_pattern(self, subj: str = None, pred: str = None, obj: str = None,
-                                   max_num_results: int = 1000):
+                                   pubkey: str = None, max_num_results: int = 1000):
         """Pattern search.
 
         Search the nanopub servers for any nanopubs matching the given RDF pattern. You can leave
@@ -81,6 +81,7 @@ class NanopubClient:
             subj (str): URI of the subject that you want to match triples on.
             pred (str): URI of the predicate that you want to match triples on.
             obj (str): URI of the object that you want to match triples on.
+            pubkey (str): Public key that the matching nanopubs should be signed with
             max_num_results (int): Maximum number of result, default = 1000
 
         Returns:
@@ -91,14 +92,18 @@ class NanopubClient:
 
         """
         params = {}
+        endpoint = 'find_nanopubs_with_pattern'
         if subj:
             params['subj'] = subj
         if pred:
             params['pred'] = pred
         if obj:
             params['obj'] = obj
+        if pubkey:
+            params['pubkey'] = pubkey
+            endpoint = 'find_signed_nanopubs_with_pattern'
 
-        return self._search(endpoint='find_nanopubs_with_pattern',
+        return self._search(endpoint=endpoint,
                             params=params,
                             max_num_results=max_num_results)
 

--- a/nanopub/client.py
+++ b/nanopub/client.py
@@ -44,7 +44,7 @@ class NanopubClient:
         else:
             self.grlc_urls = NANOPUB_GRLC_URLS
 
-    def find_nanopubs_with_text(self, text: str, max_num_results: int = 1000):
+    def find_nanopubs_with_text(self, text: str, pubkey: str = None, max_num_results: int = 1000):
         """Text search.
 
         Search the nanopub servers for any nanopubs matching the
@@ -52,6 +52,7 @@ class NanopubClient:
 
         Args:
             text (str): The text to search on
+            pubkey (str): Public key that the matching nanopubs should be signed with
             max_num_results (int): Maximum number of result, default = 1000
 
         Returns:
@@ -63,10 +64,12 @@ class NanopubClient:
         """
         if len(text) == 0:
             return []
-
+        endpoint = 'find_nanopubs_with_text'
         params = {'text': text, 'graphpred': '', 'month': '', 'day': '', 'year': ''}
-
-        return self._search(endpoint='find_nanopubs_with_text',
+        if pubkey:
+            params['pubkey'] = pubkey
+            endpoint = 'find_signed_nanopubs_with_text'
+        return self._search(endpoint=endpoint,
                             params=params,
                             max_num_results=max_num_results)
 
@@ -107,7 +110,7 @@ class NanopubClient:
                             params=params,
                             max_num_results=max_num_results)
 
-    def find_things(self, type: str, searchterm: str = ' ',
+    def find_things(self, type: str, searchterm: str = ' ', pubkey: str = None,
                     max_num_results=1000):
         """Search things (experimental).
 
@@ -117,6 +120,7 @@ class NanopubClient:
         Args:
             type (str): A URI denoting the type of the introduced concept
             searchterm (str): The term that you want to search on
+            pubkey (str): Public key that the matching nanopubs should be signed with
             max_num_results (int): Maximum number of result, default = 1000
 
         Returns:
@@ -128,14 +132,17 @@ class NanopubClient:
         """
         if searchterm == '':
             raise ValueError(f'Searchterm can not be an empty string: {searchterm}')
-
+        endpoint = 'find_things'
         params = dict()
         params['type'] = type
         params['searchterm'] = searchterm
+        if pubkey:
+            params['pubkey'] = pubkey
+            endpoint = 'find_signed_things'
 
-        return self._search(endpoint='find_things',
+        return self._search(endpoint=endpoint,
                             params=params,
-                            max_num_results=max_num_results, )
+                            max_num_results=max_num_results)
 
     def find_retractions_of(self, uri: str) -> List[str]:
         """Find retractions of given URI

--- a/nanopub/publication.py
+++ b/nanopub/publication.py
@@ -30,10 +30,10 @@ class Publication:
             applicable)
         introduces_concept: The concept that is introduced by this Publication.
         signed_with_public_key: The public key that this Publication is signed with.
-
+        is_test_publication: Whether this is a test publication
     """
 
-    def __init__(self, rdf=None, source_uri=None):
+    def __init__(self, rdf, source_uri=None):
         self._rdf = rdf
         self._source_uri = source_uri
 
@@ -300,6 +300,13 @@ class Publication:
             return public_key
         else:
             return None
+
+    @property
+    def is_test_publication(self) -> bool:
+        if self._source_uri is None:
+            return None
+        else:
+            return 'test' in self._source_uri
 
     def __str__(self):
         s = f'Original source URI = {self._source_uri}\n'

--- a/nanopub/publication.py
+++ b/nanopub/publication.py
@@ -33,7 +33,7 @@ class Publication:
         is_test_publication: Whether this is a test publication
     """
 
-    def __init__(self, rdf, source_uri=None):
+    def __init__(self, rdf: rdflib.ConjunctiveGraph, source_uri: str = None):
         self._rdf = rdf
         self._source_uri = source_uri
 

--- a/nanopub/publication.py
+++ b/nanopub/publication.py
@@ -3,6 +3,7 @@
 This module holds code for representing the RDF of nanopublications, as well as helper functions to
 make handling RDF easier.
 """
+import warnings
 from datetime import datetime
 from urllib.parse import urldefrag
 
@@ -28,6 +29,7 @@ class Publication:
         source_uri (str): The URI of the nanopublication that this Publication represents (if
             applicable)
         introduces_concept: The concept that is introduced by this Publication.
+        signed_with_public_key: The public key that this Publication is signed with.
 
     """
 
@@ -273,6 +275,31 @@ class Publication:
             return concepts_introduced[0]
         else:
             raise ValueError('Nanopub introduces multiple concepts')
+
+    @property
+    def _self_ref(self):
+        """Get the self reference (i.e. 'this') from the header.
+
+        This is usually something like:
+        http://purl.org/np/RAnksi2yDP7jpe7F6BwWCpMOmzBEcUImkAKUeKEY_2Yus
+        """
+        return list(self._graphs['head'].subjects(predicate=rdflib.RDF.type,
+                                                  object=namespaces.NP.Nanopublication))[0]
+
+    @property
+    def signed_with_public_key(self):
+        if not self._source_uri:
+            return None
+        public_keys = list(self.pubinfo.objects(self._self_ref + '#sig',
+                                                namespaces.NPX.hasPublicKey))
+        if len(public_keys) > 0:
+            public_key = str(public_keys[0])
+            if len(public_keys) > 1:
+                warnings.warn(f'Nanopublication is signed with multiple public keys, we will use '
+                              f'this one: {public_key}')
+            return public_key
+        else:
+            return None
 
     def __str__(self):
         s = f'Original source URI = {self._source_uri}\n'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,6 +67,14 @@ class TestNanopubClient:
         with pytest.raises(Exception):
             client.find_things()
 
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
+    def test_find_retractions_of(self):
+        uri = 'http://purl.org/np/RAnksi2yDP7jpe7F6BwWCpMOmzBEcUImkAKUeKEY_2Yus'
+        results = client.find_retractions_of(uri)
+        expected_retraction_uri = 'http://purl.org/np/RAYhe0XddJhBsJvVt0h_aq16p6f94ymc2wS-q2BAgnPVY'
+        assert expected_retraction_uri in results
+
     def test_nanopub_search(self):
         with pytest.raises(Exception):
             client._search(params=None,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,9 @@ from nanopub import NanopubClient, namespaces, Publication
 client = NanopubClient(use_test_server=True)
 
 TEST_ASSERTION = (namespaces.AUTHOR.DrBob, namespaces.HYCL.claims, rdflib.Literal('This is a test'))
+PUBKEY = 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCC686zsZaQWthNDSZO6unvhtSkXSLT8iSY/UUwD/' \
+         '7T9tabrEvFt/9UPsCsg/A4HG6xeuPtL5mVziVnzbxqi9myQOY62LBja85pYLWaZPUYakP' \
+         'HyVm9A0bRC2PUYZde+METkZ6eoqLXP26Qo5b6avPcmNnKkr5OQb7KXaeX2K2zQQIDAQAB'
 
 
 class TestNanopubClient:
@@ -26,6 +29,15 @@ class TestNanopubClient:
             assert len(results) > 0
 
         assert len(client.find_nanopubs_with_text('')) == 0
+
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
+    def test_find_nanopubs_with_text_pubkey(self):
+        results = client.find_nanopubs_with_text('test', pubkey=PUBKEY)
+        assert len(results) > 0
+
+        results = client.find_nanopubs_with_text('test', pubkey='wrong')
+        assert len(results) == 0
 
     @pytest.mark.flaky(max_runs=10)
     def test_find_nanopubs_with_text_prod(self):
@@ -61,17 +73,12 @@ class TestNanopubClient:
         """
             Check that Nanopub pattern search is returning results
         """
-        pubkey = 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCC686zsZaQWthNDSZO6unvhtSkXSLT8iSY/UUwD/' \
-                 '7T9tabrEvFt/9UPsCsg/A4HG6xeuPtL5mVziVnzbxqi9myQOY62LBja85pYLWaZPUYakP' \
-                 'HyVm9A0bRC2PUYZde+METkZ6eoqLXP26Qo5b6avPcmNnKkr5OQb7KXaeX2K2zQQIDAQAB'
         subj, pred, obj = (
             'http://purl.org/np/RA8ui7ddvV25m1qdyxR4lC8q8-G0yb3SN8AC0Bu5q8Yeg', '', '')
-        results = client.find_nanopubs_with_pattern(subj=subj, pred=pred, obj=obj, pubkey=pubkey)
+        results = client.find_nanopubs_with_pattern(subj=subj, pred=pred, obj=obj, pubkey=PUBKEY)
         assert len(results) > 0
 
-        wrong_pubkey = 'wrong public key'
-        results = client.find_nanopubs_with_pattern(subj=subj, pred=pred, obj=obj,
-                                                    pubkey=wrong_pubkey)
+        results = client.find_nanopubs_with_pattern(subj=subj, pred=pred, obj=obj, pubkey='wrong')
         assert len(results) == 0
 
     @pytest.mark.flaky(max_runs=10)
@@ -85,6 +92,15 @@ class TestNanopubClient:
 
         with pytest.raises(Exception):
             client.find_things()
+
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
+    def test_find_things_pubkey(self):
+        results = client.find_things(type='http://purl.org/net/p-plan#Plan', pubkey=PUBKEY)
+        assert len(results) > 0
+
+        results = client.find_things(type='http://purl.org/net/p-plan#Plan', pubkey='wrong')
+        assert len(results) == 0
 
     @pytest.mark.flaky(max_runs=10)
     @skip_if_nanopub_server_unavailable

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -98,53 +98,6 @@ class TestNanopubClient:
 
     @pytest.mark.flaky(max_runs=10)
     @skip_if_nanopub_server_unavailable
-    def test_find_valid_signed_nanopubs_with_text(self):
-        """
-        Check that Nanopub text search is returning results for a few common search terms
-        for signed and not retracted nanopubs
-        """
-        searches = ['test', 'US']
-
-        for search in searches:
-            results = client.find_valid_signed_nanopubs_with_text(search)
-            assert len(results) > 0
-
-        assert len(client.find_valid_signed_nanopubs_with_text('')) == 0
-
-    @pytest.mark.flaky(max_runs=10)
-    @skip_if_nanopub_server_unavailable
-    def test_find_valid_signed_nanopubs_with_pattern(self):
-        """
-            Check that Nanopub pattern search is returning results
-            for signed and not retracted nanopubs
-        """
-        searches = [
-            ('', '', ''),
-            ('', '', 'http://purl.org/net/p-plan#Plan'),
-            ('', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
-                'http://purl.org/net/p-plan#Plan')
-        ]
-
-        for subj, pred, obj in searches:
-            results = client.find_valid_signed_nanopubs_with_pattern(subj=subj, pred=pred, obj=obj)
-            assert len(results) > 0
-            assert 'Error' not in results[0]
-
-    @pytest.mark.flaky(max_runs=10)
-    @skip_if_nanopub_server_unavailable
-    def test_nanopub_find_valid_signed_things(self):
-        """
-        Check that Nanopub 'find_things' search is returning results
-        for signed and not retracted nanopubs
-        """
-        results = client.find_valid_signed_things(type='http://purl.org/net/p-plan#Plan')
-        assert len(results) > 0
-
-        with pytest.raises(Exception):
-            client.find_valid_signed_things()
-
-    @pytest.mark.flaky(max_runs=10)
-    @skip_if_nanopub_server_unavailable
     def test_find_things_pubkey(self):
         results = client.find_things(type='http://purl.org/net/p-plan#Plan', pubkey=PUBKEY)
         assert len(results) > 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,6 +57,25 @@ class TestNanopubClient:
 
     @pytest.mark.flaky(max_runs=10)
     @skip_if_nanopub_server_unavailable
+    def test_find_nanopubs_with_pattern_pubkey(self):
+        """
+            Check that Nanopub pattern search is returning results
+        """
+        pubkey = 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCC686zsZaQWthNDSZO6unvhtSkXSLT8iSY/UUwD/' \
+                 '7T9tabrEvFt/9UPsCsg/A4HG6xeuPtL5mVziVnzbxqi9myQOY62LBja85pYLWaZPUYakP' \
+                 'HyVm9A0bRC2PUYZde+METkZ6eoqLXP26Qo5b6avPcmNnKkr5OQb7KXaeX2K2zQQIDAQAB'
+        subj, pred, obj = (
+            'http://purl.org/np/RA8ui7ddvV25m1qdyxR4lC8q8-G0yb3SN8AC0Bu5q8Yeg', '', '')
+        results = client.find_nanopubs_with_pattern(subj=subj, pred=pred, obj=obj, pubkey=pubkey)
+        assert len(results) > 0
+
+        wrong_pubkey = 'wrong public key'
+        results = client.find_nanopubs_with_pattern(subj=subj, pred=pred, obj=obj,
+                                                    pubkey=wrong_pubkey)
+        assert len(results) == 0
+
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
     def test_nanopub_find_things(self):
         """
         Check that Nanopub 'find_things' search is returning results

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -61,7 +61,7 @@ class TestNanopubClient:
             Check that Nanopub pattern search is returning results
         """
         searches = [
-            ('', 'http://example.org/transmits', 'http://example.org/malaria'),
+            ('', rdflib.RDF.type, rdflib.FOAF.Person),
             ('http://purl.org/np/RA8ui7ddvV25m1qdyxR4lC8q8-G0yb3SN8AC0Bu5q8Yeg', '', '')
         ]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -151,6 +151,19 @@ class TestNanopubClient:
 
     @pytest.mark.flaky(max_runs=10)
     @skip_if_nanopub_server_unavailable
+    def test_find_things_filter_retracted(self):
+        filtered_results = client.find_things(type='http://purl.org/net/p-plan#Plan',
+                                              filter_retracted=True)
+        assert len(filtered_results) > 0
+        all_results = client.find_things(type='http://purl.org/net/p-plan#Plan',
+                                         filter_retracted=False)
+        assert len(all_results) > 0
+        # The filtered results should be a smaller subset of all the results, assuming that some of
+        # the results are retracted nanopublications.
+        assert len(all_results) > len(filtered_results)
+
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
     def test_find_retractions_of(self):
         uri = 'http://purl.org/np/RAnksi2yDP7jpe7F6BwWCpMOmzBEcUImkAKUeKEY_2Yus'
         results = client.find_retractions_of(uri, valid_only=False)

--- a/tests/test_publication.py
+++ b/tests/test_publication.py
@@ -122,6 +122,16 @@ class TestPublication:
         public_key = publication.signed_with_public_key
         assert public_key is None
 
+    @pytest.mark.parametrize('source_uri,expected', [
+        ('http://test-server.nanopubs.lod.labs.vu.nl/foo', True),
+        ('http://purl.org/np/bar', False),
+        (None, None)])
+    def test_is_test_publication(self, source_uri, expected):
+        test_rdf = rdflib.ConjunctiveGraph()
+        test_rdf.parse(NANOPUB_SAMPLE_UNSIGNED, format='trig')
+        publication = Publication(test_rdf, source_uri=source_uri)
+        assert publication.is_test_publication == expected
+
 
 def test_replace_in_rdf():
     g = rdflib.Graph()

--- a/tests/test_publication.py
+++ b/tests/test_publication.py
@@ -4,9 +4,11 @@ import pytest
 import rdflib
 
 from nanopub import namespaces, Publication, replace_in_rdf
-from nanopub.definitions import DUMMY_NANOPUB_URI
+from nanopub.definitions import DUMMY_NANOPUB_URI, TEST_RESOURCES_FILEPATH
 
 TEST_ORCID_ID = 'https://orcid.org/0000-0000-0000-0000'
+NANOPUB_SAMPLE_SIGNED = str(TEST_RESOURCES_FILEPATH / 'nanopub_sample_signed.trig')
+NANOPUB_SAMPLE_UNSIGNED = str(TEST_RESOURCES_FILEPATH / 'nanopub_sample_unsigned.trig')
 
 
 class TestPublication:
@@ -103,6 +105,22 @@ class TestPublication:
                                        pubinfo_rdf=pubinfo_rdf,
                                        introduces_concept=rdflib.URIRef('example'))
         Publication.from_assertion(assertion_rdf=self.test_rdf)
+
+    def test_signed_with_public_key(self):
+        test_rdf = rdflib.ConjunctiveGraph()
+        test_rdf.parse(NANOPUB_SAMPLE_SIGNED, format='trig')
+        uri = 'http://purl.org/np/RAzPytdERsBd378zHGvwgRbat1MCiS7QrxNrPxe9yDu6E'
+        publication = Publication(test_rdf, source_uri=uri)
+        public_key = publication.signed_with_public_key
+        assert public_key is not None
+
+    def test_signed_with_public_key_not_signed(self):
+        test_rdf = rdflib.ConjunctiveGraph()
+        test_rdf.parse(NANOPUB_SAMPLE_UNSIGNED, format='trig')
+        uri = 'http://purl.org/np/RAzPytdERsBd378zHGvwgRbat1MCiS7QrxNrPxe9yDu6E'
+        publication = Publication(test_rdf, source_uri=uri)
+        public_key = publication.signed_with_public_key
+        assert public_key is None
 
 
 def test_replace_in_rdf():


### PR DESCRIPTION
### Added
* `pubkey` option to methods of `NanopubClient` that allows searching for publications 
signed with the given pubkey. For these methods:
    - `find_nanopubs_with_text`
    - `find_nanopubs_with_pattern`
    - `find_things`
* `filter_retracted` option to methods of `NanopubClient` that allows searching for publications 
    that are not retracted. For these methods:
    - `find_nanopubs_with_text`
    - `find_nanopubs_with_pattern`
    - `find_things`
* `NanopubClient.find_retractions_of` method to search retractions of a given nanopublication.
* `Publication.signed_with_public_key` property: the public key that the publication was signed with.
* `Publication.is_test_publication` property: denoting whether this is a publicaion on the test server.

I did not add a `is_retracted` property to the `Publication` class, because we would have to instantiate a `NanopubClient` in the `Publication` object. Then you get all kinds of circular import problems, and the problem that you cannot specify whether you want to use `test` or `prod` server. So users just have to use `NanopubClient.find_retractions_of` to know whether a publication was retracted (I added documentation on this).