### PR TITLE
Add find signed valid nanopublications calls

### DIFF
--- a/nanopub/client.py
+++ b/nanopub/client.py
@@ -127,8 +127,8 @@ class NanopubClient:
                             params=params,
                             max_num_results=max_num_results)
 
-    def find_valid_signed_nanopubs_with_pattern(self, subj: str = None, pred: str = None, obj: str = None,
-                                   max_num_results: int = 1000):
+    def find_valid_signed_nanopubs_with_pattern(self, subj: str = None, pred: str = None,
+                                                obj: str = None, max_num_results: int = 1000):
         """Pattern search in nanopubs that are signed and not retracted.
 
         Search the nanopub servers for any nanopubs matching the given RDF pattern. You can leave
@@ -189,9 +189,8 @@ class NanopubClient:
                             params=params,
                             max_num_results=max_num_results, )
 
-
     def find_valid_signed_things(self, type: str, searchterm: str = ' ',
-                    max_num_results=1000):
+                                 max_num_results=1000):
         """Search things that are signed and not retracted (experimental).
 
         Search for any nanopublications that introduce a concept of the given type, that contain

--- a/nanopub/client.py
+++ b/nanopub/client.py
@@ -69,6 +69,32 @@ class NanopubClient:
                             params=params,
                             max_num_results=max_num_results)
 
+    def find_valid_signed_nanopubs_with_text(self, text: str, max_num_results: int = 1000):
+        """Text search in nanopubs that are signed and not retracted.
+
+        Search the nanopub servers for any nanopubs matching the
+        given search text.
+
+        Args:
+            text (str): The text to search on
+            max_num_results (int): Maximum number of result, default = 1000
+
+        Returns:
+            List of dicts depicting matching nanopublications.
+            Each dict holds: 'np': the nanopublication uri,
+            'date': date of creation of the nanopublication,
+            'description': A description of the nanopublication (if found in RDF).
+
+        """
+        if len(text) == 0:
+            return []
+
+        params = {'text': text, 'graphpred': '', 'month': '', 'day': '', 'year': ''}
+
+        return self._search(endpoint='find_valid_signed_nanopubs_with_text',
+                            params=params,
+                            max_num_results=max_num_results)
+
     def find_nanopubs_with_pattern(self, subj: str = None, pred: str = None, obj: str = None,
                                    max_num_results: int = 1000):
         """Pattern search.
@@ -101,6 +127,38 @@ class NanopubClient:
                             params=params,
                             max_num_results=max_num_results)
 
+    def find_valid_signed_nanopubs_with_pattern(self, subj: str = None, pred: str = None, obj: str = None,
+                                   max_num_results: int = 1000):
+        """Pattern search in nanopubs that are signed and not retracted.
+
+        Search the nanopub servers for any nanopubs matching the given RDF pattern. You can leave
+        parts of the triple to match anything by not specifying subj, pred, or obj arguments.
+
+        Args:
+            subj (str): URI of the subject that you want to match triples on.
+            pred (str): URI of the predicate that you want to match triples on.
+            obj (str): URI of the object that you want to match triples on.
+            max_num_results (int): Maximum number of result, default = 1000
+
+        Returns:
+            List of dicts depicting matching nanopublications.
+            Each dict holds: 'np': the nanopublication uri,
+            'date': date of creation of the nanopublication,
+            'description': A description of the nanopublication (if found in RDF).
+
+        """
+        params = {}
+        if subj:
+            params['subj'] = subj
+        if pred:
+            params['pred'] = pred
+        if obj:
+            params['obj'] = obj
+
+        return self._search(endpoint='find_valid_signed_nanopubs_with_pattern',
+                            params=params,
+                            max_num_results=max_num_results)
+
     def find_things(self, type: str, searchterm: str = ' ',
                     max_num_results=1000):
         """Search things (experimental).
@@ -128,6 +186,37 @@ class NanopubClient:
         params['searchterm'] = searchterm
 
         return self._search(endpoint='find_things',
+                            params=params,
+                            max_num_results=max_num_results, )
+
+
+    def find_valid_signed_things(self, type: str, searchterm: str = ' ',
+                    max_num_results=1000):
+        """Search things that are signed and not retracted (experimental).
+
+        Search for any nanopublications that introduce a concept of the given type, that contain
+        text with the given search term.
+
+        Args:
+            type (str): A URI denoting the type of the introduced concept
+            searchterm (str): The term that you want to search on
+            max_num_results (int): Maximum number of result, default = 1000
+
+        Returns:
+            List of dicts depicting matching nanopublications.
+            Each dict holds: 'np': the nanopublication uri,
+            'date': date of creation of the nanopublication,
+            'description': A description of the nanopublication (if found in RDF).
+
+        """
+        if searchterm == '':
+            raise ValueError(f'Searchterm can not be an empty string: {searchterm}')
+
+        params = dict()
+        params['type'] = type
+        params['searchterm'] = searchterm
+
+        return self._search(endpoint='find_valid_signed_things',
                             params=params,
                             max_num_results=max_num_results, )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,6 +67,49 @@ class TestNanopubClient:
         with pytest.raises(Exception):
             client.find_things()
 
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
+    def test_find_valid_signed_nanopubs_with_text(self):
+        """
+        Check that Nanopub text search is returning results for a few common search terms
+        """
+        searches = ['covid-19', 'europe']
+
+        for search in searches:
+            results = client.find_valid_signed_nanopubs_with_text(search)
+            assert len(results) > 0
+
+        assert len(client.find_valid_signed_nanopubs_with_text('')) == 0
+
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
+    def test_find_valid_signed_nanopubs_with_pattern(self):
+        """
+            Check that Nanopub pattern search is returning results
+        """
+        searches = [
+            ('', '', ''),
+            ('', '', 'http://purl.org/net/p-plan#Plan'),
+            ('', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://purl.org/net/p-plan#Plan')
+        ]
+
+        for subj, pred, obj in searches:
+            results = client.find_valid_signed_nanopubs_with_pattern(subj=subj, pred=pred, obj=obj)
+            assert len(results) > 0
+            assert 'Error' not in results[0]
+
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
+    def test_nanopub_find_valid_signed_things(self):
+        """
+        Check that Nanopub 'find_things' search is returning results
+        """
+        results = client.find_valid_signed_things(type='http://purl.org/net/p-plan#Plan')
+        assert len(results) > 0
+
+        with pytest.raises(Exception):
+            client.find_valid_signed_things()
+
     def test_nanopub_search(self):
         with pytest.raises(Exception):
             client._search(params=None,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -90,9 +90,9 @@ class TestNanopubClient:
             for signed and not retracted nanopubs
         """
         searches = [
-            ('', '', ''),
-            ('', '', 'http://purl.org/net/p-plan#Plan'),
-            ('', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://purl.org/net/p-plan#Plan')
+          ('', '', ''),
+          ('', '', 'http://purl.org/net/p-plan#Plan'),
+          ('', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://purl.org/net/p-plan#Plan')
         ]
 
         for subj, pred, obj in searches:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -71,7 +71,8 @@ class TestNanopubClient:
     @skip_if_nanopub_server_unavailable
     def test_find_valid_signed_nanopubs_with_text(self):
         """
-        Check that Nanopub text search is returning results for a few common search terms for signed and not retracted nanopubs
+        Check that Nanopub text search is returning results for a few common search terms
+        for signed and not retracted nanopubs
         """
         searches = ['covid-19', 'europe']
 
@@ -85,7 +86,8 @@ class TestNanopubClient:
     @skip_if_nanopub_server_unavailable
     def test_find_valid_signed_nanopubs_with_pattern(self):
         """
-            Check that Nanopub pattern search is returning results for signed and not retracted nanopubs
+            Check that Nanopub pattern search is returning results
+            for signed and not retracted nanopubs
         """
         searches = [
             ('', '', ''),
@@ -102,7 +104,8 @@ class TestNanopubClient:
     @skip_if_nanopub_server_unavailable
     def test_nanopub_find_valid_signed_things(self):
         """
-        Check that Nanopub 'find_things' search is returning results for signed and not retracted nanopubs
+        Check that Nanopub 'find_things' search is returning results
+        for signed and not retracted nanopubs
         """
         results = client.find_valid_signed_things(type='http://purl.org/net/p-plan#Plan')
         assert len(results) > 0

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -92,7 +92,7 @@ class TestNanopubClient:
         searches = [
             ('', '', ''),
             ('', '', 'http://purl.org/net/p-plan#Plan'),
-            ('', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 
+            ('', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
                 'http://purl.org/net/p-plan#Plan')
         ]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,7 +74,7 @@ class TestNanopubClient:
         Check that Nanopub text search is returning results for a few common search terms
         for signed and not retracted nanopubs
         """
-        searches = ['covid-19', 'europe']
+        searches = ['test', 'US']
 
         for search in searches:
             results = client.find_valid_signed_nanopubs_with_text(search)
@@ -90,9 +90,10 @@ class TestNanopubClient:
             for signed and not retracted nanopubs
         """
         searches = [
-          ('', '', ''),
-          ('', '', 'http://purl.org/net/p-plan#Plan'),
-          ('', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://purl.org/net/p-plan#Plan')
+            ('', '', ''),
+            ('', '', 'http://purl.org/net/p-plan#Plan'),
+            ('', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 
+                'http://purl.org/net/p-plan#Plan')
         ]
 
         for subj, pred, obj in searches:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -71,7 +71,7 @@ class TestNanopubClient:
     @skip_if_nanopub_server_unavailable
     def test_find_valid_signed_nanopubs_with_text(self):
         """
-        Check that Nanopub text search is returning results for a few common search terms
+        Check that Nanopub text search is returning results for a few common search terms for signed and not retracted nanopubs
         """
         searches = ['covid-19', 'europe']
 
@@ -85,7 +85,7 @@ class TestNanopubClient:
     @skip_if_nanopub_server_unavailable
     def test_find_valid_signed_nanopubs_with_pattern(self):
         """
-            Check that Nanopub pattern search is returning results
+            Check that Nanopub pattern search is returning results for signed and not retracted nanopubs
         """
         searches = [
             ('', '', ''),
@@ -102,7 +102,7 @@ class TestNanopubClient:
     @skip_if_nanopub_server_unavailable
     def test_nanopub_find_valid_signed_things(self):
         """
-        Check that Nanopub 'find_things' search is returning results
+        Check that Nanopub 'find_things' search is returning results for signed and not retracted nanopubs
         """
         results = client.find_valid_signed_things(type='http://purl.org/net/p-plan#Plan')
         assert len(results) > 0


### PR DESCRIPTION
Related to issue https://github.com/fair-workflows/nanopub/issues/92

The 3 methods have been added
- [x] `find_valid_signed_nanopubs_with_text`
- [x] `find_valid_signed_nanopubs_with_pattern`
- [x] `find_valid_signed_things`

All interesting changes are done in the first commit, the rest are just commits to fix flake8 linting errors
I added a test for each call, and the tests are passing:

https://github.com/vemonet/nanopub/runs/1540063021?check_suite_focus=true

(apart the last step to publish to coverall, which should be expected to fail I guess)