### PR TITLE
Issue119 orcid regex

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,18 +7,13 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.6]
-
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: 3.7
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * Make `nanopub` package compatible Windows operating system
+* Make regex in orcid validation accept ids ending with 'X'
 
 ## [1.2.0] - 2020-12-23
 

--- a/nanopub/setup_nanopub_profile.py
+++ b/nanopub/setup_nanopub_profile.py
@@ -19,7 +19,7 @@ DEFAULT_KEYS_PATH_PREFIX = USER_CONFIG_DIR / 'id'
 DEFAULT_PRIVATE_KEY_PATH = USER_CONFIG_DIR / PRIVATE_KEY_FILE
 DEFAULT_PUBLIC_KEY_PATH = USER_CONFIG_DIR / PUBLIC_KEY_FILE
 RSA = 'RSA'
-ORCID_ID_REGEX = r'^https://orcid.org/(\d{4}-){3}\d{4}$'
+ORCID_ID_REGEX = r'^https://orcid.org/(\d{4}-){3}\d{3}(\d|X)$'
 
 
 def validate_orcid_id(ctx, orcid_id: str):

--- a/tests/test_setup_profile.py
+++ b/tests/test_setup_profile.py
@@ -100,8 +100,11 @@ def test_create_this_is_me_rdf():
 
 
 def test_validate_orcid_id():
-    valid_id = 'https://orcid.org/1234-5678-1234-5678'
-    assert validate_orcid_id(ctx=None, orcid_id=valid_id) == valid_id
+    valid_ids = ['https://orcid.org/1234-5678-1234-5678',
+                 'https://orcid.org/1234-5678-1234-567X']
+    for orcid_id in valid_ids:
+        assert validate_orcid_id(ctx=None, orcid_id=orcid_id) == orcid_id
+
     invalid_ids = ['https://orcid.org/abcd-efgh-abcd-efgh',
                    'https://orcid.org/1234-5678-1234-567',
                    'https://orcid.org/1234-5678-1234-56789',


### PR DESCRIPTION
Addressing #119 

Regex should now allow orcids ending in X. This does not do the checksum though.