### PR TITLE
Add more tests 20210122

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -146,11 +146,25 @@ class TestNanopubClient:
     def test_find_retractions_of_publication_raise_warning(self):
         test_rdf = rdflib.ConjunctiveGraph()
         test_rdf.parse(NANOPUB_SAMPLE_SIGNED, format='trig')
+
         # A test publication
         publication = Publication(rdf=test_rdf, source_uri='http://test-server/example')
         assert publication.is_test_publication
         # Production server client
         client = NanopubClient(use_test_server=False)
+        client.find_nanopubs_with_pattern = mock.MagicMock()
+        # Because we try searching the prod server with a test publication this should trigger a
+        # warning.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            client.find_retractions_of(publication, valid_only=False)
+            assert len(w) == 1
+
+        # Not a test publication
+        publication = Publication(rdf=test_rdf, source_uri='http://a-real-server/example')
+        assert not publication.is_test_publication
+        # Production server client
+        client = NanopubClient(use_test_server=True)
         client.find_nanopubs_with_pattern = mock.MagicMock()
         # Because we try searching the prod server with a test publication this should trigger a
         # warning.

--- a/tests/test_publication.py
+++ b/tests/test_publication.py
@@ -135,7 +135,7 @@ class TestPublication:
     def test_construct_with_empty_rdf(self):
         test_rdf = rdflib.ConjunctiveGraph()
         with pytest.raises(ValueError):
-            publication = Publication(rdf=test_rdf)
+            Publication(rdf=test_rdf)
 
 
 def test_replace_in_rdf():

--- a/tests/test_publication.py
+++ b/tests/test_publication.py
@@ -132,6 +132,11 @@ class TestPublication:
         publication = Publication(test_rdf, source_uri=source_uri)
         assert publication.is_test_publication == expected
 
+    def test_construct_with_empty_rdf(self):
+        test_rdf = rdflib.ConjunctiveGraph()
+        with pytest.raises(ValueError):
+            publication = Publication(rdf=test_rdf)
+
 
 def test_replace_in_rdf():
     g = rdflib.Graph()


### PR DESCRIPTION
Add a couple more tests to get the coverage back up. Tests are for trying to construct a ```Publication``` with an empty rdf graph, and trying to ```find_retractions_of``` for non-test publications on a test server.