### PR TITLE
Use 3-arg click callback for `validate_orcid_id`

### DIFF
--- a/nanopub/setup_nanopub_profile.py
+++ b/nanopub/setup_nanopub_profile.py
@@ -21,10 +21,11 @@ RSA = 'RSA'
 ORCID_ID_REGEX = r'^https://orcid.org/(\d{4}-){3}\d{3}(\d|X)$'
 
 
-def validate_orcid_id(ctx, orcid_id: str):
+def validate_orcid_id(ctx, param, orcid_id: str):
     """
     Check if valid ORCID iD, should be https://orcid.org/ + 16 digit in form:
-        https://orcid.org/0000-0000-0000-0000
+        https://orcid.org/0000-0000-0000-0000. ctx and param are
+        necessary `click` callback arguments
     """
     if re.match(ORCID_ID_REGEX, orcid_id):
         return orcid_id

--- a/tests/test_setup_profile.py
+++ b/tests/test_setup_profile.py
@@ -103,7 +103,7 @@ def test_validate_orcid_id():
     valid_ids = ['https://orcid.org/1234-5678-1234-5678',
                  'https://orcid.org/1234-5678-1234-567X']
     for orcid_id in valid_ids:
-        assert validate_orcid_id(ctx=None, orcid_id=orcid_id) == orcid_id
+        assert validate_orcid_id(ctx=None, param=None, orcid_id=orcid_id) == orcid_id
 
     invalid_ids = ['https://orcid.org/abcd-efgh-abcd-efgh',
                    'https://orcid.org/1234-5678-1234-567',
@@ -112,4 +112,4 @@ def test_validate_orcid_id():
                    '0000-0000-0000-0000']
     for orcid_id in invalid_ids:
         with pytest.raises(ValueError):
-            validate_orcid_id(ctx=None, orcid_id=orcid_id)
+            validate_orcid_id(ctx=None, param=None, orcid_id=orcid_id)


### PR DESCRIPTION
Fixes #120 by adding the `param` argument to the click callback, this is mandatory since version 8.0.