### PR TITLE
Allow rdflib v5 and v6

### DIFF
--- a/nanopub/publication.py
+++ b/nanopub/publication.py
@@ -341,7 +341,7 @@ class Publication:
         np_serialized = self._rdf.serialize(format='trig')
 
         # In rdflib v5, .serialize() returns a bytes object that needs to be decoded.
-        # (rdflib 6+ returns a str) 
+        # (rdflib 6+ returns a str)
         if isinstance(np_serialized, bytes):
             np_serialized = np_serialized.decode('utf-8')
 

--- a/nanopub/publication.py
+++ b/nanopub/publication.py
@@ -337,7 +337,16 @@ class Publication:
 
     def __str__(self):
         s = f'Original source URI = {self._source_uri}\n'
-        s += self._rdf.serialize(format='trig').decode('utf-8')
+
+        np_serialized = self._rdf.serialize(format='trig')
+
+        # In rdflib v5, .serialize() returns a bytes object that needs to be decoded.
+        # (rdflib 6+ returns a str) 
+        if isinstance(np_serialized, bytes):
+            np_serialized = np_serialized.decode('utf-8')
+
+        s += np_serialized
+
         return s
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rdflib<6.0.0,>=5.0.0
+rdflib<=7.0.0,>=5.0.0
 requests
 click==7.1.2
 yatiml


### PR DESCRIPTION
Make modifications to allow `rdflib` version 6 to work too.

Fixes #148 