### PR TITLE
Fix how introduces_concept is handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![nanopub](https://img.shields.io/badge/rsd-nanopub-00a3e3.svg)](https://www.research-software.nl/software/nanopub)
-![Build Status](https://github.com/fair-workflows/nanopub/workflows/Python%20application/badge.svg)
-[![Documentation Status](https://readthedocs.org/projects/nanopub/badge/?version=latest)](https://nanopub.readthedocs.io/en/latest/?badge=latest)
+[![Tests and update docs](https://github.com/fair-workflows/nanopub/actions/workflows/build.yml/badge.svg)](https://github.com/fair-workflows/nanopub/actions/workflows/build.yml) [![Publish to PyPI](https://github.com/fair-workflows/nanopub/actions/workflows/pypi.yml/badge.svg)](https://github.com/fair-workflows/nanopub/actions/workflows/pypi.yml)
 [![Coverage Status](https://coveralls.io/repos/github/fair-workflows/nanopub/badge.svg?branch=main)](https://coveralls.io/github/fair-workflows/nanopub?branch=main)
 [![PyPI version](https://badge.fury.io/py/nanopub.svg)](https://badge.fury.io/py/nanopub)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/4491/badge)](https://bestpractices.coreinfrastructure.org/projects/4491)

--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -13,7 +13,7 @@ import requests
 from rdflib import BNode, ConjunctiveGraph, Graph, URIRef
 from rdflib.namespace import DC, DCTERMS, FOAF, PROV, RDF, XSD
 
-from nanopub.definitions import DUMMY_NANOPUB_URI, MAX_TRIPLES_PER_NANOPUB, NANOPUB_FETCH_FORMAT, NANOPUB_TEST_SERVER
+from nanopub.definitions import MAX_TRIPLES_PER_NANOPUB, NANOPUB_FETCH_FORMAT, NANOPUB_TEST_SERVER
 from nanopub.namespaces import HYCL, NP, NPX, NTEMPLATE, ORCID, PAV
 from nanopub.nanopub_conf import NanopubConf
 from nanopub.profile import ProfileError
@@ -201,18 +201,19 @@ class Nanopub:
         self.published = True
 
         if self._introduces_concept:
-            concept_uri = str(self._introduces_concept)
+            # concept_uri = str(self._introduces_concept)
             # Replace the DUMMY_NANOPUB_URI with the actually published nanopub uri. This is
             # necessary if a blank node was passed as introduces_concept. In that case the
             # Nanopub.from_assertion method replaces the blank node with the base nanopub's URI
             # and appends a fragment, given by the 'name' of the blank node. For example, if a
             # blank node with name 'step' was passed as introduces_concept, the concept will be
             # published with a URI that looks like [published nanopub URI]#step.
-            concept_uri = concept_uri.replace(
-                DUMMY_NANOPUB_URI, self.source_uri
-            )
-            self._concept_uri = concept_uri
-            log.info(f"Published concept to {concept_uri}")
+            # concept_uri = concept_uri.replace(
+            #     DUMMY_NANOPUB_URI, self.source_uri
+            # )
+            # NOTE: introduces_concept is always a blank node
+            self._concept_uri = f"{self.source_uri}#{str(self._introduces_concept)}"
+            log.info(f"Published concept to {self._concept_uri}")
 
 
     def update(self, publish=True) -> None:

--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -47,7 +47,8 @@ class Nanopub:
     ) -> None:
         self._profile = conf.profile
         self._source_uri = source_uri
-        self._concept_uri = None
+        self._introduces_concept = introduces_concept
+        self._concept_uri: Optional[str] = None
         self._conf = deepcopy(conf)
         self._metadata = NanopubMetadata()
         self._published = False
@@ -199,8 +200,8 @@ class Nanopub:
         log.info(f'Published {self.source_uri} to {self._conf.use_server}')
         self.published = True
 
-        if self.introduces_concept:
-            concept_uri = str(self.introduces_concept)
+        if self._introduces_concept:
+            concept_uri = str(self._introduces_concept)
             # Replace the DUMMY_NANOPUB_URI with the actually published nanopub uri. This is
             # necessary if a blank node was passed as introduces_concept. In that case the
             # Nanopub.from_assertion method replaces the blank node with the base nanopub's URI

--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -210,7 +210,7 @@ class Nanopub:
             concept_uri = concept_uri.replace(
                 DUMMY_NANOPUB_URI, self.source_uri
             )
-            self.concept_uri = concept_uri
+            self._concept_uri = concept_uri
             log.info(f"Published concept to {concept_uri}")
 
 

--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -201,17 +201,9 @@ class Nanopub:
         self.published = True
 
         if self._introduces_concept:
-            # concept_uri = str(self._introduces_concept)
-            # Replace the DUMMY_NANOPUB_URI with the actually published nanopub uri. This is
-            # necessary if a blank node was passed as introduces_concept. In that case the
-            # Nanopub.from_assertion method replaces the blank node with the base nanopub's URI
-            # and appends a fragment, given by the 'name' of the blank node. For example, if a
-            # blank node with name 'step' was passed as introduces_concept, the concept will be
+            # introduces_concept is always a blank node.
+            # If a blank node with name 'step' was passed as introduces_concept, the concept will be
             # published with a URI that looks like [published nanopub URI]#step.
-            # concept_uri = concept_uri.replace(
-            #     DUMMY_NANOPUB_URI, self.source_uri
-            # )
-            # NOTE: introduces_concept is always a blank node
             self._concept_uri = f"{self.source_uri}#{str(self._introduces_concept)}"
             log.info(f"Published concept to {self._concept_uri}")
 


### PR DESCRIPTION
@raar1 While upgrading the `fairworkflow` library I noticed an issue with how `introduces_concept` is handled, especially when generating the concept URI. So here is a fix!