### PR TITLE
Fix searching for nanopubs example in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ print(np)
 from nanopub import NanopubClient
 
 # Search for all nanopublications containing the text 'fair'
+client = NanopubClient()
 results = client.find_nanopubs_with_text('fair')
 print(results)
 ```


### PR DESCRIPTION
The example omitted initializing the `client` variable.