### PR TITLE
Fix nanopub-java version to 1.47

### DIFF
--- a/scripts/nanopub-java
+++ b/scripts/nanopub-java
@@ -4,14 +4,14 @@ set -e
 
 function download-nanopub-jar {
   mkdir -p $LIBDIR
-  echo "Getting latest nanopub version..."
-  NANOPUB_LATEST_LOCATION=$(
-    curl --head -s https://github.com/Nanopublication/nanopub-java/releases/latest \
-    | egrep -i '^location:'
-  )
-  NANOPUB_VERSION=${NANOPUB_LATEST_LOCATION##*-}
-  NANOPUB_VERSION="${NANOPUB_VERSION%"${NANOPUB_VERSION##*[![:space:]]}"}"
-  # NANOPUB_VERSION=1.38
+  # echo "Getting latest nanopub version..."
+  # NANOPUB_LATEST_LOCATION=$(
+  #   curl --head -s https://github.com/Nanopublication/nanopub-java/releases/latest \
+  #   | egrep -i '^location:'
+  # )
+  # NANOPUB_VERSION=${NANOPUB_LATEST_LOCATION##*-}
+  # NANOPUB_VERSION="${NANOPUB_VERSION%"${NANOPUB_VERSION##*[![:space:]]}"}"
+  NANOPUB_VERSION=1.47
   echo "Downloading nanopub jar file version $NANOPUB_VERSION in $LIBDIR/nanopub-${NANOPUB_VERSION}-jar-with-dependencies.jar"
   curl -L --output "$LIBDIR/nanopub-${NANOPUB_VERSION}-jar-with-dependencies.jar" "https://github.com/Nanopublication/nanopub-java/releases/download/nanopub-${NANOPUB_VERSION}/nanopub-${NANOPUB_VERSION}-jar-with-dependencies.jar"
 }


### PR DESCRIPTION
1.47 is the latest version using purl.org (tests fails when using the new w3id.org version because it generates different hashes) @raar1 