### PR TITLE
Integrate Local Blazegraph SPARQL Endpoint

### DIFF
--- a/nanopub/definitions.py
+++ b/nanopub/definitions.py
@@ -8,6 +8,8 @@ TEST_RESOURCES_FILEPATH = TESTS_FILEPATH / "resources"
 USER_CONFIG_DIR = Path.home() / ".nanopub"
 DEFAULT_PROFILE_PATH = USER_CONFIG_DIR / "profile.yml"
 
+BLAZEGRAPH_SERVER = 'http://localhost:9999/blazegraph/namespace/kb/sparql'
+
 NANOPUB_TEST_SERVER = 'https://np.test.knowledgepixels.com/'
 # List of servers: https://monitor.petapico.org/.csv
 NANOPUB_SERVER_LIST = [

--- a/nanopub/nanopub.py
+++ b/nanopub/nanopub.py
@@ -194,11 +194,11 @@ class Nanopub:
 
 
     def publish(self) -> None:
-        """Publish a Nanopub object"""
+        """Publish a Nanopub object & optionally update the blazegraph sparql endpoint"""
         if not self.source_uri:
             self.sign()
 
-        publish_graph(self.rdf, use_server=self._conf.use_server)
+        publish_graph(self.rdf, use_server=self._conf.use_server, publish_to_blazegraph=self._conf.publish_to_blazegraph, blazegraph_server=self._conf.blazegraph_server)
         log.info(f'Published {self.source_uri} to {self._conf.use_server}')
         self.published = True
 

--- a/nanopub/nanopub_conf.py
+++ b/nanopub/nanopub_conf.py
@@ -1,7 +1,7 @@
 from dataclasses import asdict, dataclass
 from typing import Optional
 
-from nanopub.definitions import NANOPUB_SERVER_LIST
+from nanopub.definitions import NANOPUB_SERVER_LIST, BLAZEGRAPH_SERVER
 from nanopub.profile import Profile
 
 
@@ -23,6 +23,9 @@ class NanopubConf:
     """
 
     profile: Optional[Profile] = None
+
+    publish_to_blazegraph: bool = False
+    blazegraph_server: str = BLAZEGRAPH_SERVER
 
     use_test_server: bool = False
     use_server: str = NANOPUB_SERVER_LIST[0]

--- a/nanopub/utils.py
+++ b/nanopub/utils.py
@@ -7,7 +7,16 @@ from rdflib import ConjunctiveGraph, Namespace, URIRef
 
 from nanopub.definitions import DUMMY_NAMESPACE, DUMMY_URI
 
-log = logging.getLogger()
+logging.basicConfig(
+    filename='app.log',
+    filemode='a',
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+
+log = logging.getLogger(__name__)
+
+log.info("Logger initialized. Starting the application.")
 
 
 class MalformedNanopubError(ValueError):

--- a/nanopub/utils.py
+++ b/nanopub/utils.py
@@ -7,16 +7,7 @@ from rdflib import ConjunctiveGraph, Namespace, URIRef
 
 from nanopub.definitions import DUMMY_NAMESPACE, DUMMY_URI
 
-logging.basicConfig(
-    filename='app.log',
-    filemode='a',
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-
-log = logging.getLogger(__name__)
-
-log.info("Logger initialized. Starting the application.")
+log = logging.getLogger()
 
 
 class MalformedNanopubError(ValueError):


### PR DESCRIPTION
### Summary
This pull request introduces functionality that allows all nanopublications being published using this library to update a local Blazegraph SPARQL endpoint. This feature is primarily designed for development and testing environments, enabling users to keep their data private by running both the nanopub-server and blazegraph locally.

### Key Features

- **Optional Blazegraph Updates:** Users can choose whether to update the Blazegraph endpoint when publishing a nanopublication. The default setting is false.

- **Customizable Endpoint:** By default, the endpoint is set to http://localhost:9999/blazegraph/namespace/kb/sparql. Users can easily change `localhost:9999` to match their Blazegraph server's address while keeping the namespace and path intact.

### Benefits
This enhancement facilitates local development and testing while ensuring that all data remains private and doesn't clutter the original servers. It simplifies the workflow for developers who want to integrate nanopublications with Blazegraph without exposing their data to external servers too.